### PR TITLE
⚡ Bolt: Remove redundant LOWER() calls in SQLite LIKE clauses

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1106,8 +1106,9 @@ class GraphStore:
             WHERE (
                 SELECT COUNT(*)
                 FROM json_each(?)
-                WHERE LOWER(nodes.name) LIKE '%' || LOWER(value) || '%'
-                   OR LOWER(nodes.qualified_name) LIKE '%' || LOWER(value) || '%'
+                -- ⚡ Bolt: removed LOWER() because SQLite LIKE is case-insensitive for ASCII strings.
+                WHERE nodes.name LIKE '%' || value || '%'
+                   OR nodes.qualified_name LIKE '%' || value || '%'
             ) = (SELECT COUNT(*) FROM json_each(?))
               AND (? IS NULL OR kind = ?)
               AND (? = '' OR repo_id = ?){frag}


### PR DESCRIPTION
💡 **What**: Removed redundant `LOWER()` function calls in the `search_nodes` SQLite query in `GraphStore` when used with the `LIKE` operator.

🎯 **Why**: In SQLite, the `LIKE` operator is inherently case-insensitive for ASCII characters by default. Using `LOWER()` around the columns and parameters forces the database engine to evaluate a function on every row and search term during a query scan, adding unnecessary overhead (especially since wildcards `%` prevent index usage anyway).

📊 **Impact**: Saves CPU cycles per evaluated row during table scan queries in `search_nodes`. Reduces database computation overhead. 

🔬 **Measurement**: Verify by running `uv run pytest tests/test_graph.py::test_search_nodes` to ensure search behavior remains identical (still matches case-insensitively).

---
*PR created automatically by Jules for task [8009838502164892656](https://jules.google.com/task/8009838502164892656) started by @n24q02m*