### PR TITLE
⚡ Bolt: [performance improvement] Optimize SQLite `LIKE` in keyword search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,8 @@
 **Learning:** Direct SQL execution within a loop structure causes N+1 query patterns, leading to significant performance degradation as the data set grows. In SQLite, this is especially impactful during write-heavy operations like temporal closing.
 
 **Action:** Refactor row-by-row updates into batch operations using `UPDATE ... WHERE ... IN (SELECT value FROM json_each(?))`. This pushes the filtering logic into the database engine and reduces the overhead of multiple `execute()` calls and potential transaction management. Always use `cursor.rowcount` to track affected rows when removing the manual loop counter.
+
+## $(date +%Y-%m-%d) - Eliminate Redundant LOWER() calls in SQLite LIKE queries
+
+**Learning:** By default, SQLite's `LIKE` operator is already case-insensitive for ASCII characters. Furthermore, SQLite's built-in `LOWER()` function also only operates on ASCII characters. Therefore, applying `LOWER()` to both sides of a `LIKE` operator is strictly redundant and causes unnecessary per-row function evaluation overhead during table scans.
+**Action:** When writing `LIKE` queries in SQLite where case-insensitive ASCII comparison is sufficient, do not wrap the operands in `LOWER()`. This eliminates per-row evaluation overhead and optimizes the table scan speed.

--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1106,8 +1106,9 @@ class GraphStore:
             WHERE (
                 SELECT COUNT(*)
                 FROM json_each(?)
-                WHERE LOWER(nodes.name) LIKE '%' || LOWER(value) || '%'
-                   OR LOWER(nodes.qualified_name) LIKE '%' || LOWER(value) || '%'
+                /* Performance Optimization: Removed LOWER() because SQLite LIKE is case-insensitive for ASCII, reducing per-row evaluation overhead. */
+                WHERE nodes.name LIKE '%' || value || '%'
+                   OR nodes.qualified_name LIKE '%' || value || '%'
             ) = (SELECT COUNT(*) FROM json_each(?))
               AND (? IS NULL OR kind = ?)
               AND (? = '' OR repo_id = ?){frag}

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.19.0"
+version = "3.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
💡 What: Removed `LOWER()` function calls around `nodes.name`, `nodes.qualified_name`, and `value` in the `LIKE` clause of the `search_nodes` query in `GraphStore`.
🎯 Why: SQLite's default `LIKE` operator is already case-insensitive for ASCII characters. Using `LOWER()` causes unnecessary per-row function evaluation overhead during the table scan, slowing down keyword searches.
📊 Impact: Reduces per-row evaluation overhead during keyword searches, making the scan faster, particularly on large graphs.
🔬 Measurement: Verify by running tests (`uv run pytest tests/test_graph.py::test_search_nodes`) to ensure search functionality and case-insensitivity remain intact.

---
*PR created automatically by Jules for task [10407347876855017150](https://jules.google.com/task/10407347876855017150) started by @n24q02m*