### PR TITLE
🛡️ Sentinel: [HIGH] Fix Git argument injection in is_valid_commit

### DIFF
--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -203,6 +203,8 @@ def is_valid_commit(repo_root: Path, sha: str) -> bool:
     """Return True if sha identifies a reachable commit object."""
     if not sha:
         return False
+    if sha.startswith("-"):
+        return False
     result = _run_git(repo_root, ["cat-file", "-e", f"{sha}^{{commit}}"])
     return result is not None and result.returncode == 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.19.1"
+version = "3.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential argument injection when executing `git cat-file`. Unvalidated `sha` parameters beginning with `-` could be interpreted as options rather than object names.
🎯 Impact: Could allow arbitrary option flags to be injected into git commands, potentially leading to unauthorized repository access or manipulation, although the immediate attack surface is limited by the structure of `git cat-file`.
🔧 Fix: Added explicit check `sha.startswith("-")` in `is_valid_commit` to reject potentially malicious inputs.
✅ Verification: Ran `uv run pytest` and verified all tests pass without regression. Checked `is_valid_commit` behaves as expected.

---
*PR created automatically by Jules for task [13530224560549912213](https://jules.google.com/task/13530224560549912213) started by @n24q02m*