### PR TITLE
🛡️ Sentinel: [HIGH] Fix command option/argument injection in git CLI wrapper

### DIFF
--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -201,7 +201,7 @@ def get_head_sha(repo_root: Path) -> str | None:
 
 def is_valid_commit(repo_root: Path, sha: str) -> bool:
     """Return True if sha identifies a reachable commit object."""
-    if not sha:
+    if not sha or sha.startswith("-"):
         return False
     result = _run_git(repo_root, ["cat-file", "-e", f"{sha}^{{commit}}"])
     return result is not None and result.returncode == 0

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.19.1"
+version = "3.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command option/argument injection in `is_valid_commit(repo_root: Path, sha: str)` when `sha` parameter starts with a hyphen.
🎯 Impact: An attacker could potentially pass options like `--open-files-in-pager` to `git cat-file`, leading to unexpected behavior or potential command execution.
🔧 Fix: Add `sha.startswith("-")` validation before calling `git cat-file`.
✅ Verification: `uv run pytest` and linters pass.

---
*PR created automatically by Jules for task [9452864381507454163](https://jules.google.com/task/9452864381507454163) started by @n24q02m*