### PR TITLE
fix: recognise .test./.spec. filenames when excluding test helpers

### DIFF
--- a/src/better_code_review_graph/docs/graph.md
+++ b/src/better_code_review_graph/docs/graph.md
@@ -223,4 +223,11 @@ not excluded. A call written inside a helper belongs to that helper, so
 indirect reach is not credited to the test. Read `tests_for` results and the
 untested-function warning in `get_review_context` with that meaning in mind.
 
+That exclusion recognises a test file **by filename**, using the same patterns
+that classify a test function. A module whose name merely looks like one --
+`test_fixtures.py` holding sample data, or `Testimonial.py` -- is treated as a
+test file too, so functions defined in it never receive a `TESTED_BY` edge and
+stay in the untested list even when a test calls them. If a function you expect
+to be covered keeps appearing there, check the filename first.
+
 Qualified names use `file_path::name` format (e.g. `src/auth.py::authenticate`). Cross-repo edges produced by federation prefix the target with the owning `repo_id`: `<repo_id>:<file_path>::<symbol>` (see "Federation: cross-repo graphs" above).

--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -219,11 +219,19 @@ def _is_test_file(qualified_or_path: str) -> bool:
     living in a non-test module (``support.py``, a fixtures package) are not
     detectable this way and do produce an edge -- see the TESTED_BY note in
     ``docs/graph.md``.
+
+    Both the stem and the full filename are checked because the patterns split
+    across the two: ``_test$`` / ``_spec$`` anchor on a stem (``foo_test.go``),
+    while ``\\.test\\.`` / ``\\.spec\\.`` need the extension still attached
+    (``foo.spec.ts`` has stem ``foo.spec``, which no pattern matches).
     """
     path = qualified_or_path.split("::", 1)[0]
     if not path:
         return False
-    return any(p.search(Path(path).stem) for p in _TEST_PATTERNS)
+    candidate = Path(path)
+    return any(
+        p.search(candidate.stem) or p.search(candidate.name) for p in _TEST_PATTERNS
+    )
 
 
 def file_hash(path: Path) -> str:

--- a/tests/test_tested_by_edges.py
+++ b/tests/test_tested_by_edges.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from better_code_review_graph.graph import GraphStore
 from better_code_review_graph.incremental import full_build, get_db_path
-from better_code_review_graph.parser import CodeParser
+from better_code_review_graph.parser import CodeParser, _is_test_file
 from better_code_review_graph.tools import (
     _compute_untested_functions,
     query_graph,
@@ -167,6 +167,42 @@ class TestTestedByScope:
 
         targets = {e.target for e in edges if e.kind == "TESTED_BY"}
         assert not any(t.endswith("::add") for t in targets)
+
+
+class TestIsTestFileNamingConventions:
+    """The exclusion recognises a test file by name across languages.
+
+    The patterns split across two forms: ``_test$`` / ``_spec$`` anchor on the
+    stem, while ``.test.`` / ``.spec.`` only match with the extension still
+    attached. Checking one form alone silently misses the other family.
+    """
+
+    def test_recognises_conventions_from_several_languages(self):
+        for path in (
+            "test_calculator.py",
+            "calculator_test.go",
+            "widget.test.ts",
+            "widget.spec.tsx",
+            "model_spec.rb",
+        ):
+            assert _is_test_file(path), path
+
+    def test_ordinary_modules_are_not_test_files(self):
+        for path in ("support.py", "calculator.py", "contest.py"):
+            assert not _is_test_file(path), path
+
+    def test_accepts_a_qualified_name_as_well_as_a_path(self):
+        assert _is_test_file("pkg/widget.spec.ts::helper")
+        assert not _is_test_file("pkg/widget.ts::helper")
+
+    def test_a_module_merely_named_like_a_test_is_treated_as_one(self):
+        """Documented limitation, asserted so it is not mistaken for a bug.
+
+        Detection is by filename, so a data module called Testimonial.py is
+        excluded too. docs/graph.md tells readers to check the filename when
+        a function keeps showing up as untested.
+        """
+        assert _is_test_file("Testimonial.py")
 
 
 class TestTestsForFindsUnconventionallyNamedTests:


### PR DESCRIPTION
A correction to #909, plus the detection limit written down where readers will hit it.

## The bug

`_is_test_file` matched `_TEST_PATTERNS` against `Path(path).stem` only. That splits the pattern set in half:

| pattern | anchors on | example |
|---|---|---|
| `^test_`, `^Test`, `_test$`, `_spec$` | stem | `foo_test.go` -> stem `foo_test`, matches |
| `\.test\.`, `\.spec\.` | full filename | `foo.spec.ts` -> stem `foo.spec`, **no match** |

Measured on the shipped code:

```
bar.spec.ts   -> False
foo.test.ts   -> False
comp.test.tsx -> False
foo_test.go   -> True
util_spec.rb  -> True
```

So every JavaScript and TypeScript test file went unrecognised, and helpers defined in one still produced `TESTED_BY` edges — the exact false positive #909 set out to remove. The #909 PR body claimed `.spec.ts` was covered. It was not; I asserted that from reading the regex list instead of running it.

Both the stem and the full filename are now checked, which covers both families. After the fix all five cases above return `True`, while `support.py`, `calculator.py` and `contest.py` stay `False`.

## Detection limit, now documented

Recognition is by filename, so a module that merely looks like a test is treated as one: `test_fixtures.py` holding sample data, or `Testimonial.py`. Functions defined there never receive a `TESTED_BY` edge and stay in the untested list even when a test calls them.

That failure direction is under-reporting coverage, which is the safer of the two, but it produces a confusing result. `docs/graph.md` now says so and tells the reader to check the filename first when a function they expect to be covered keeps appearing as untested.

Not worth a bespoke pattern set: `_is_test_function` carries the same risk from the same patterns, and a second, subtly different definition of "test" inside one parser would be worse than the shared limitation.

## Tests

`TestIsTestFileNamingConventions` — four cases: conventions across five languages, ordinary modules excluded, qualified names (`pkg/widget.spec.ts::helper`) accepted alongside bare paths, and the `Testimonial.py` limitation asserted so it reads as a decision rather than a bug.

`tests/test_tested_by_edges.py` is now 12 tests, all in the default suite. Full default suite: 1365 passed, 1 skipped.