### PR TITLE
fix: bolt optimization pushing kind filtering to database for get_edges_by_targets

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1047,7 +1047,11 @@ class GraphStore:
         return f" AND kind IN ({placeholders})", tuple(kind)
 
     def get_edges_by_targets(
-        self, qualified_names: list[str], *, as_of: str = ""
+        self,
+        qualified_names: list[str],
+        kind: str | tuple[str, ...] | None = None,
+        *,
+        as_of: str = "",
     ) -> list[GraphEdge]:
         """Batch fetch edges by their target qualified names to prevent N+1 queries."""
         if not qualified_names:
@@ -1055,10 +1059,11 @@ class GraphStore:
 
         unique_qns = list(set(qualified_names))
         frag, frag_params = self._temporal_filter(as_of)
+        kind_frag, kind_params = self._kind_filter(kind)
         cursor = self._conn.execute(
             "SELECT * FROM edges WHERE target_qualified IN "  # noqa: S608
-            f"(SELECT value FROM json_each(?)){frag}",
-            (json.dumps(unique_qns), *frag_params),
+            f"(SELECT value FROM json_each(?)){kind_frag}{frag}",
+            (json.dumps(unique_qns), *kind_params, *frag_params),
         )
         return [self._row_to_edge(r) for r in cursor]
 

--- a/src/better_code_review_graph/incremental.py
+++ b/src/better_code_review_graph/incremental.py
@@ -344,10 +344,11 @@ def find_dependents(store: GraphStore, file_path: str) -> list[str]:
     nodes = store.get_nodes_by_file(file_path)
     qns = [n.qualified_name for n in nodes]
     if qns:
-        batch_edges = store.get_edges_by_targets(qns)
+        batch_edges = store.get_edges_by_targets(
+            qns, kind=("CALLS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS")
+        )
         for e in batch_edges:
-            if e.kind in ("CALLS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS"):
-                dependents.add(e.file_path)
+            dependents.add(e.file_path)
 
     dependents.discard(file_path)
     return list(dependents)


### PR DESCRIPTION
💡 What: Updates `GraphStore.get_edges_by_targets` to natively accept a `kind` filter (similar to `get_edges_by_target`) and pushes this filter down to the backend SQLite query via `_kind_filter`. Updates `find_dependents` in `incremental.py` to utilize this.
🎯 Why: Previously, `get_edges_by_targets` fetched all incoming edges pointing to the target nodes into memory, materializing complete `GraphEdge` dictionaries, only for `find_dependents` to discard most of them using a Python `if e.kind in ...` loop. This caused inefficient memory usage and processing overhead, specifically during batched traversal operations in complex repositories.
📊 Impact: Expected to reduce memory footprint and execution time for dependency traversals by eliminating the N+1 Python-side filtering over materialized rows.
🔬 Measurement: Run a traversal test involving multiple files with extensive unrelated edges. Time without optimization vs time with optimization.

---
*PR created automatically by Jules for task [6232709120287205533](https://jules.google.com/task/6232709120287205533) started by @n24q02m*