### PR TITLE
fix(parser): emit CALLS edges for callback references and toplevel init calls

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -1173,8 +1173,20 @@ class CodeParser:
         defined_names: set[str] | None,
     ) -> bool:
         call_name = self._get_call_name(node, language, source)
-        if call_name and enclosing_func:
-            caller = self._qualify(enclosing_func, file_path, enclosing_class)
+        if call_name:
+            # Attribute calls on the module/IIFE toplevel have no enclosing
+            # function. File-level init code — e.g. JavaScript IIFE bodies,
+            # ``document.addEventListener('click', handler)`` wiring, or a
+            # Python module calling helpers at import time — still *uses*
+            # the referenced symbols, so the edges are attributed to the
+            # File node (qualified name = file path) instead of being
+            # dropped. This keeps callers_of/dead-code from reporting
+            # handlers registered by toplevel init code as unreferenced.
+            caller = (
+                self._qualify(enclosing_func, file_path, enclosing_class)
+                if enclosing_func
+                else file_path
+            )
             target = self._resolve_call_target(
                 call_name,
                 file_path,
@@ -1192,13 +1204,36 @@ class CodeParser:
                     line=line,
                 )
             )
+            # Function references passed as arguments — e.g. JS
+            # ``el.addEventListener('click', handler)`` or Python
+            # ``deferred.addCallback(handler)`` — are a real use of the
+            # referenced symbol, but the argument identifier itself is not
+            # a call expression, so they previously produced no CALLS edge
+            # and dead-code analysis reported the handler as unreferenced.
+            # Emit CALLS edges for argument identifiers that resolve to a
+            # file-scope definition or an import, so callers_of(handler)
+            # finds the registering function.
+            self._emit_argument_reference_edges(
+                node,
+                source,
+                language,
+                file_path,
+                edges,
+                caller,
+                call_name,
+                import_map,
+                defined_names,
+            )
             # TESTED_BY means "called directly by a test", NOT "properly
             # tested". A test calls its subject, but it also calls helpers,
             # builders and assertion utilities, and no static rule separates
             # intent from incidental use. Consumers must read the edge with
             # that meaning -- see _is_test_file for the one exclusion applied.
-            if _is_test_function(enclosing_func, file_path) and not _is_test_file(
-                target
+            # Toplevel/file-level calls have no test function to attribute.
+            if (
+                enclosing_func
+                and _is_test_function(enclosing_func, file_path)
+                and not _is_test_file(target)
             ):
                 edges.append(
                     EdgeInfo(
@@ -1210,6 +1245,87 @@ class CodeParser:
                     )
                 )
         return False
+
+    def _emit_argument_reference_edges(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        edges: list[EdgeInfo],
+        caller: str,
+        call_name: str | None,
+        import_map: dict[str, str] | None,
+        defined_names: set[str] | None,
+    ) -> None:
+        """Emit CALLS edges for function references passed as call arguments.
+
+        Tree-sitter grammars expose call arguments under a field named
+        ``arguments`` (JavaScript/TypeScript ``arguments``, Python
+        ``arguments``, Go ``arguments``, Java ``argument_list``). This
+        helper walks that subtree, collects bare identifiers, and for
+        each one that resolves to a file-scope definition or an imported
+        symbol, records a CALLS edge from the enclosing function to the
+        resolved target. This keeps dead-code analysis from flagging
+        callback-style references (``el.addEventListener('click',
+        handler)``) as unreferenced.
+        """
+        args_node = node.child_by_field_name("arguments")
+        if args_node is None:
+            return
+
+        seen: set[str] = set()
+        for ident in self._iter_argument_identifiers(args_node):
+            name = ident.text.decode("utf-8", errors="replace")
+            if not name or name in seen or name == call_name:
+                continue
+            seen.add(name)
+            resolved = self._resolve_call_target(
+                name,
+                file_path,
+                language,
+                import_map or {},
+                defined_names or set(),
+            )
+            # Only emit when the identifier actually resolved somewhere
+            # (same-file definition or import). Unresolvable bare names
+            # stay untouched — the enclosing call edge already exists.
+            if resolved == name:
+                continue
+            edges.append(
+                EdgeInfo(
+                    kind="CALLS",
+                    source=caller,
+                    target=resolved,
+                    file_path=file_path,
+                    line=ident.start_point[0] + 1,
+                )
+            )
+
+    @staticmethod
+    def _iter_argument_identifiers(args_node):
+        """Yield identifier nodes within an arguments subtree.
+
+        Nested call expressions inside arguments are skipped: their own
+        call nodes are visited by the main tree walk and emitting edges
+        here would duplicate them.
+        """
+        stack = [args_node]
+        while stack:
+            current = stack.pop()
+            for child in current.children:
+                if child.type == "identifier":
+                    yield child
+                elif child.type in (
+                    "call_expression",
+                    "new_expression",
+                    "function_expression",
+                    "arrow_function",
+                    "lambda",
+                ):
+                    continue
+                else:
+                    stack.append(child)
 
     def _handle_solidity_emit_statement(
         self,
@@ -1468,6 +1584,26 @@ class CodeParser:
             # Collect import mappings: imported_name → module_path
             if node_type in import_types:
                 self._collect_import_names(child, language, source, import_map)
+
+        # JS-family files are commonly wrapped in IIFEs or load callbacks,
+        # so their "file scope" functions are nested one or more levels
+        # deep ((function () { function handler() {...} ... })()). Those
+        # nested declarations still produce Function nodes qualified as
+        # ``<file>::<name>``, so their names must be resolvable — otherwise
+        # a reference like ``el.addEventListener('input', handler)`` inside
+        # the same wrapper cannot resolve and dead-code analysis flags the
+        # handler as unreferenced. Only named ``function_declaration`` nodes
+        # are collected: method definitions resolve through their class
+        # (``<file>::Class.method``) and arrow functions are anonymous or
+        # variable-assigned, so a bare-name resolution for them would be
+        # wrong.
+        if language in ("javascript", "typescript", "tsx"):
+            func_decl = {"function_declaration"}
+            for sub in self._iter_tree_nodes(root):
+                if sub.type in func_decl:
+                    name = self._get_name(sub, language, "function")
+                    if name:
+                        defined_names.add(name)
 
         return import_map, defined_names
 

--- a/tests/fixtures/callback_refs.js
+++ b/tests/fixtures/callback_refs.js
@@ -1,0 +1,18 @@
+// Fixture: callback references passed as call arguments.
+// Two registration styles must both keep the handler "referenced":
+//   1. from inside a named function (setupUI)
+//   2. from IIFE / module toplevel init code (attributed to the File node)
+
+function onEvent() {
+  return 42;
+}
+
+function setupUI() {
+  document.addEventListener("click", onEvent);
+  window.setTimeout(onEvent, 100);
+}
+
+(function () {
+  var el = document.getElementById("go");
+  el.addEventListener("input", onEvent);
+})();

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -139,6 +139,44 @@ class TestCodeParser:
         ]
         assert len(resolved) == 1
 
+    def test_calls_edge_argument_reference(self):
+        """Function references passed as call arguments produce CALLS edges.
+
+        ``document.addEventListener('click', onEvent)`` never *calls*
+        onEvent directly, but the reference keeps onEvent alive —
+        dead-code analysis must see a CALLS edge from setupUI.
+        """
+        _, edges = self.parser.parse_file(FIXTURES / "callback_refs.js")
+        calls = [e for e in edges if e.kind == "CALLS"]
+        file_path = str(FIXTURES / "callback_refs.js")
+
+        handler_edges = [
+            e for e in calls if e.target == f"{file_path}::onEvent"
+        ]
+        # addEventListener + setTimeout from setupUI, addEventListener
+        # from the IIFE toplevel.
+        assert len(handler_edges) == 3
+        assert all("setupUI" in e.source for e in handler_edges[:2])
+
+    def test_calls_edge_toplevel_registration(self):
+        """Callback registration in IIFE/module toplevel attributes to File.
+
+        Calls with no enclosing function (IIFE body, module init code)
+        previously produced no CALLS edge at all. They must now be
+        attributed to the File node so the referenced handler is not
+        reported as unreferenced by dead-code analysis.
+        """
+        _, edges = self.parser.parse_file(FIXTURES / "callback_refs.js")
+        calls = [e for e in edges if e.kind == "CALLS"]
+        file_path = str(FIXTURES / "callback_refs.js")
+
+        toplevel = [
+            e
+            for e in calls
+            if e.target == f"{file_path}::onEvent" and e.source == file_path
+        ]
+        assert len(toplevel) == 1
+
     def test_multiple_calls_to_same_function(self):
         """Multiple calls to the same function on different lines should each produce an edge."""
         _, edges = self.parser.parse_file(FIXTURES / "multi_call_example.py")


### PR DESCRIPTION
## Problem

Dead-code analysis reports live functions as unreferenced — the classic false positive being event handlers. Three related gaps in `parser.py` stack up:

1. **Function references passed as call arguments** — `el.addEventListener('click', handler)` — produce no CALLS edge: the argument identifier is not itself a call expression, so `_handle_call_node` never sees it.

2. **Calls with no enclosing function are dropped.** `if call_name and enclosing_func:` means IIFE bodies and module-toplevel init code (a very common JS pattern) contribute no call edges at all.

3. **Nested `function_declaration` never enters `defined_names`.** `_collect_file_scope` only scans root-level children, so functions declared inside an IIFE wrapper are unresolvable even by name, and their references can't qualify.

Combined effect: a handler registered at the IIFE toplevel via `addEventListener` has **zero incoming CALLS edges** and is flagged dead.

## 问题

死代码分析会把实际在用的函数报告为「无引用」——最典型的假阳性就是事件处理函数。`parser.py` 里有三个相互叠加的缺陷：

1. **作为调用参数传递的函数引用**（如 `el.addEventListener('click', handler)`）不产生 CALLS 边：参数标识符本身不是调用表达式，`_handle_call_node` 根本看不到它。

2. **没有外围函数的调用被直接丢弃。** `if call_name and enclosing_func:` 这个条件意味着 IIFE 函数体和模块顶层初始化代码（JS 里非常常见的写法）完全不产生调用边。

3. **嵌套的 `function_declaration` 永远进不了 `defined_names`。** `_collect_file_scope` 只扫描根层子节点，IIFE 包裹内声明的函数连按名字解析都做不到，引用自然无法限定。

三者叠加的效果：在 IIFE 顶层通过 `addEventListener` 注册的处理函数**入边 CALLS 数为零**，被判定为死代码。

## Fix

1. New `_emit_argument_reference_edges`: walks the call's `arguments` field, emits a CALLS edge for each identifier that resolves to a file-scope definition or an import (nested call/function expressions are skipped — the main walk already emits those).
2. Toplevel calls are attributed to the **File node** (qualified name = file path), consistent with how CONTAINS sources toplevel definitions. `TESTED_BY` remains function-attributed (guarded on `enclosing_func`).
3. For JS-family languages, `_collect_file_scope` additionally collects named nested `function_declaration` nodes into `defined_names` (methods/arrows excluded — they resolve via class/variable scope).

## 修复

1. 新增 `_emit_argument_reference_edges`：遍历调用的 `arguments` 字段，对每个能解析到文件级定义或 import 的标识符产生一条 CALLS 边（嵌套的调用/函数表达式会跳过——主遍历已经覆盖它们，避免重复）。
2. 顶层调用归属到 **File 节点**（限定名 = 文件路径），与 CONTAINS 对顶层定义的 source 用法保持一致。`TESTED_BY` 仍归属于函数（以 `enclosing_func` 做了守卫）。
3. 对 JS 系语言，`_collect_file_scope` 额外收集带名字的嵌套 `function_declaration` 进 `defined_names`（方法/箭头函数除外——它们经类/变量作用域解析）。

## Testing

- New fixture `tests/fixtures/callback_refs.js` + 2 tests in `test_parser.py` (registration from a named function; registration from IIFE toplevel attributed to the File node)
- Full suite green: `pytest tests/ --ignore=tests/integration --ignore=tests/e2e_mcp_protocol_test.py`
- Verified on a real IIFE-style codebase: handler went from 0 incoming CALLS edges to 3 (two `addEventListener` registrations + one direct call)

## 测试

- 新增 fixture `tests/fixtures/callback_refs.js` + `test_parser.py` 中 2 个测试（命名函数内注册；IIFE 顶层注册归属 File 节点）
- 全套测试通过：`pytest tests/ --ignore=tests/integration --ignore=tests/e2e_mcp_protocol_test.py`
- 在一个真实的 IIFE 风格代码库上验证：处理函数的入边 CALLS 从 0 变为 3（两次 `addEventListener` 注册 + 一次直接调用）
