### PR TITLE
fix: push batch edge kind filtering into SQL

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1047,18 +1047,23 @@ class GraphStore:
         return f" AND kind IN ({placeholders})", tuple(kind)
 
     def get_edges_by_targets(
-        self, qualified_names: list[str], *, as_of: str = ""
+        self,
+        qualified_names: list[str],
+        kind: str | tuple[str, ...] | None = None,
+        *,
+        as_of: str = "",
     ) -> list[GraphEdge]:
-        """Batch fetch edges by their target qualified names to prevent N+1 queries."""
+        """Batch fetch edges by target names with an optional kind filter."""
         if not qualified_names:
             return []
 
         unique_qns = list(set(qualified_names))
         frag, frag_params = self._temporal_filter(as_of)
+        kind_frag, kind_params = self._kind_filter(kind)
         cursor = self._conn.execute(
             "SELECT * FROM edges WHERE target_qualified IN "  # noqa: S608
-            f"(SELECT value FROM json_each(?)){frag}",
-            (json.dumps(unique_qns), *frag_params),
+            f"(SELECT value FROM json_each(?)){kind_frag}{frag}",
+            (json.dumps(unique_qns), *kind_params, *frag_params),
         )
         return [self._row_to_edge(r) for r in cursor]
 

--- a/tests/test_graph_batch_fetch.py
+++ b/tests/test_graph_batch_fetch.py
@@ -96,6 +96,38 @@ def test_get_edges_by_targets_basic(store):
     assert sources == {"s1", "s3"}
 
 
+def test_get_edges_by_targets_kind_filter(store):
+    store.upsert_edge(
+        EdgeInfo(
+            kind="CALLS", source="caller", target="shared", file_path="a.py", line=1
+        )
+    )
+    store.upsert_edge(
+        EdgeInfo(
+            kind="CONTAINS", source="file", target="shared", file_path="a.py", line=2
+        )
+    )
+    store.upsert_edge(
+        EdgeInfo(
+            kind="INHERITS", source="child", target="base", file_path="b.py", line=3
+        )
+    )
+    store.commit()
+
+    calls = store.get_edges_by_targets(["shared", "base"], kind="CALLS")
+    assert {(edge.kind, edge.target_qualified) for edge in calls} == {
+        ("CALLS", "shared")
+    }
+
+    structural = store.get_edges_by_targets(
+        ["shared", "base"], kind=("CONTAINS", "INHERITS")
+    )
+    assert {(edge.kind, edge.target_qualified) for edge in structural} == {
+        ("CONTAINS", "shared"),
+        ("INHERITS", "base"),
+    }
+
+
 def test_get_edges_by_targets_large_batch(store):
     # Create 500 edges to exceed batch_size=450
     target_qns = []


### PR DESCRIPTION
## Summary
- add an optional string/tuple `kind` filter to `GraphStore.get_edges_by_targets`
- reuse the existing static `_kind_filter` helper and `json_each(?)` query shape
- preserve temporal filtering and add string/tuple regression coverage

## Verification
- targeted batch/kind tests: 21 passed
- full non-live suite completed at 100%
- direct `uv run --dev ty check src/`: passed
- project pre-commit hooks passed with the repository's broken WSL/mise `ty` wrapper excluded; direct type check passed

This clean replacement supersedes SQL kind-filter PRs #965, #953, #941, #937, #935, #934, and #927.