### PR TITLE
fix: batch impact radius repo filtering

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1292,10 +1292,19 @@ class GraphStore:
         # Defensive re-filter (qualified_name set above is already
         # repo-scoped, but get_nodes_by_qualified_names is repo-blind).
         if repo:
-            changed_nodes = [n for n in changed_nodes if self._node_repo_id(n) == repo]
-            impacted_nodes = [
-                n for n in impacted_nodes if self._node_repo_id(n) == repo
+            all_node_ids = [n.id for n in changed_nodes] + [
+                n.id for n in impacted_nodes
             ]
+            valid_ids: set[int] = set()
+            if all_node_ids:
+                cursor = self._conn.execute(
+                    "SELECT id FROM nodes "
+                    "WHERE repo_id = ? AND id IN (SELECT value FROM json_each(?))",
+                    (repo, json.dumps(all_node_ids)),
+                )
+                valid_ids = {row["id"] for row in cursor}
+            changed_nodes = [n for n in changed_nodes if n.id in valid_ids]
+            impacted_nodes = [n for n in impacted_nodes if n.id in valid_ids]
 
         impacted_files = list({n.file_path for n in impacted_nodes})
 


### PR DESCRIPTION
## Summary
- replace per-node `_node_repo_id` lookups in the defensive impact-radius repo filter with one static `json_each(?)` query
- preserve the existing seed/BFS repo scoping and output semantics
- retain the empty-result guard for filtered impact sets

## Verification
- repo filter and batching tests: 16 passed
- full non-live suite completed at 100%
- direct `uv run --dev ty check src/`: passed
- project pre-commit hooks passed with the repository's broken WSL/mise `ty` wrapper excluded; direct type check passed

This clean source replacement supersedes bot PR #966.