### PR TITLE
fix: align code review retrieval contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "tree-sitter-language-pack>=1.13.3,<2",
     "networkx>=3.6.1,<4",
     "watchdog>=6.0.0,<7",
-    "fastretrieval>=1.0.1",
+    "fastretrieval>=1.1.0b1,<2",
     "httpx",
     "pydantic-settings",
     # Floor tracks the current mcp-core stable for cascade parity with

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/better-code-review-graph",
-  "description": "Token-efficient code review knowledge graph: semantic search and call-graph resolution.",
+  "description": "Knowledge graph for token-efficient code reviews -- semantic search and call-graph resolution across your codebase.",
   "repository": {
     "url": "https://github.com/n24q02m/better-code-review-graph.git",
     "source": "github"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -46,6 +46,7 @@ async def test_all_tools(tmp_path):
                 "review",
                 "config",
                 "help",
+                "security",
                 "config__open_relay",
             }
             d = json.loads(
@@ -151,6 +152,19 @@ async def test_all_tools(tmp_path):
                 )
                 > 10
             )
+            security_result = json.loads(
+                (
+                    await s.call_tool(
+                        "security",
+                        {"action": "scan", "engine": "heuristic", "repo_root": rp},
+                    )
+                )
+                .content[0]
+                .text
+            )
+            assert security_result["engine"] == "heuristic"
+            assert isinstance(security_result["total"], int)
+            assert isinstance(security_result["tags_by_node"], dict)
             assert json.loads(
                 (await s.call_tool("config", {"action": "status", "repo_root": rp}))
                 .content[0]

--- a/uv.lock
+++ b/uv.lock
@@ -199,7 +199,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.5,<2" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastmcp", specifier = ">=3.4.4,<4" },
-    { name = "fastretrieval", specifier = ">=1.0.1" },
+    { name = "fastretrieval", specifier = ">=1.1.0b1,<2" },
     { name = "httpx" },
     { name = "litellm", specifier = ">=1.93.0" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
@@ -566,7 +566,7 @@ server = [
 
 [[package]]
 name = "fastretrieval"
-version = "1.0.1"
+version = "1.1.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -577,9 +577,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/35/2a91b42d6b9784ee620d4c75bd2abadbcbd3cf304dcb0a41f5a3a22ee0ba/fastretrieval-1.0.1.tar.gz", hash = "sha256:a1d766e1c1471347ba830c4a7f280ed7b0ff86fbc48425ac457b7b9d8d0e5783", size = 330230, upload-time = "2026-08-14T16:58:25.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2b/00cccf6ead62dc473fb3eccfccd222ca9f481dc85acacb568f49700d159e/fastretrieval-1.1.0b1.tar.gz", hash = "sha256:f5d0609d8255bb66647b65071c802af7401840ba6fedd0d39f93b477fba9722e", size = 330569, upload-time = "2026-08-22T12:47:25.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/94/28ba6e0d86b4b8bb0f2a687d5669bd3c6adb7c3346d6e80431fb66ba6c2d/fastretrieval-1.0.1-py3-none-any.whl", hash = "sha256:902851b02c6b1ffefc66aa63c7976a2226696d7ea2b43b9ec471029e97e58892", size = 144199, upload-time = "2026-08-14T16:58:24.195Z" },
+    { url = "https://files.pythonhosted.org/packages/51/df/bc661390b5a1f06ec476ee23e0e9e848f865b3e80543fcb74e5bf0a254b5/fastretrieval-1.1.0b1-py3-none-any.whl", hash = "sha256:a741bb849e7324d0e11d07b23237b278e45b294c1770ef9a036a77310ebb6bad", size = 144434, upload-time = "2026-08-22T12:47:24.442Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- require the published `fastretrieval>=1.1.0b1,<2` contract and lock exact 1.1.0b1
- align MCP registry description with the current product surface
- refresh the real stdio all-tools acceptance to include and exercise the `security` tool

## Verification
- `uv lock --locked`
- `uv run pytest tests -k "embedding or retrieval or setup or model" -q` — passed
- real stdio MCP graph build/update/stats, query/search/impact, review, heuristic security scan, config, and help — passed

Stable promotion is intentionally out of scope.