### PR TITLE
feat: add CRG local CLI harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
   - `incremental.py` -- Git integration, file watching, incremental updates
   - `embeddings.py` -- Dual-mode embedding: local ONNX through the fastretrieval registry + cloud chain (`EMBEDDING_MODELS`) via litellm passthrough (`mcp_core.llm`)
   - `docs/` -- Help tool documentation (graph.md, query.md, review.md, config.md)
-  - `cli.py` -- CLI: starts MCP server (pure entry point)
+- `cli.py` -- local CLI: no args starts MCP stdio; positional subcommands expose graph/query/review/security over the same domain services
+
   - `__init__.py` -- Version export
   - `__main__.py` -- `python -m` entry (calls cli.main)
   - `py.typed` -- PEP 561 marker
@@ -22,6 +23,15 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
 - `skills/` -- Claude Code skills (impact-audit, onboard-repo, refactor-check, review-delta, review-pr, security-sweep)
 - `hooks/` -- SessionStart + UserPromptSubmit + PostToolUse hooks
 - `.claude-plugin/` -- Plugin manifest + marketplace metadata
+
+## Local-first boundary
+
+- CLI and bundled Skills are the primary coding-harness surfaces.
+- MCP stdio is a secondary protocol adapter; it must not duplicate graph logic.
+- Graph state is local at `<repo>/.code-review-graph/graph.db` unless explicit
+  self-host/multi-user configuration changes the data directory.
+- CRG has no hosted Cloudflare runtime in the target topology; package, OCI,
+  CI, security, and release lifecycle remain active.
 
 ## Lenh thuong dung
 
@@ -51,7 +61,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
                                           |
                                      Embedding store --> Semantic search
                                           |
-                                     FastMCP server --> 7 tools (graph + query + review + config + security + help + config__open_relay)
+                                     FastMCP server --> secondary MCP adapter (7 tools: graph + query + review + config + security + help + config__open_relay)
 ```
 
 - **Parser** (parser.py): Tree-sitter extracts nodes (File, Class, Function, Type, Test) and edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON). Resolves same-file bare call targets to qualified names.
@@ -59,7 +69,7 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
 - **Incremental** (incremental.py): Git diff detection, file hash tracking, re-parses only changed files.
 - **Embeddings** (embeddings.py): Dual-mode -- local ONNX through the fastretrieval registry (default, zero-config) or cloud via the `EMBEDDING_MODELS` chain (litellm passthrough, `mcp_core.llm`; order = fallback, empty = local). Fixed 768-dim storage.
 - **Tools** (tools.py): Implementation layer for all graph operations. Output pagination via max_results.
-- **Server** (server.py): 7 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions/spot_check/renamed_in_diff/diff), review, config, security, help, config__open_relay (mcp-core relay helper). Returns JSON strings.
+- **Server** (server.py): 7 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions/spot_check/renamed_in_diff/diff), review, config, security, help, config__open_relay (mcp-core relay helper). Returns structured dict payloads over MCP; the CLI serializes them as JSON.
 
 ## Embedding backends
 
@@ -149,7 +159,7 @@ chối, không tự rơi về model mặc định.
 ## Luu y quan trong
 
 - Lazy imports cho heavy deps (tree-sitter, fastretrieval, litellm via `mcp_core.llm`, numpy) -- tranh startup cost
-- MCP tools return error strings (`return "Error: ..."`) -- KHONG raise exceptions
+- MCP tools return structured error payloads (`{"error": ...}`) and close local resources on every path.
 - GraphStore.upsert_edge takes EdgeInfo (fields: source, target), GraphEdge uses source_qualified/target_qualified
 - `_make_qualified()` builds qualified names as `file_path::name` or `file_path::parent.name`
 - Supported languages: Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++, Solidity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
   - `relay_setup.py` -- `apply_config` env-applier used by the OAuth setup form (live setup UX = OAuth-AS browser form at `<PUBLIC_URL>/authorize`; the `ensure_config` create-session/poll path is legacy/unused)
   - `relay_schema.py` -- Relay form schema (embedding provider fields)
   - `docs/` -- Help tool documentation (graph.md, query.md, review.md, config.md, recipes.md, security.md)
-  - `cli.py` -- CLI: starts MCP server (pure entry point)
+- `cli.py` -- local CLI: no args starts MCP stdio; positional subcommands expose graph/query/review/security over the same domain services
   - `__init__.py` -- Version export
   - `__main__.py` -- `python -m` entry (calls cli.main)
   - `py.typed` -- PEP 561 marker
@@ -24,6 +24,15 @@ See `AGENTS.md` va `README.md` de hieu architecture va configuration.
 - `skills/` -- Claude Code skills (impact-audit, onboard-repo, refactor-check, review-delta, review-pr, security-sweep)
 - `hooks/` -- SessionStart + UserPromptSubmit + PostToolUse hooks
 - `.claude-plugin/` -- Plugin manifest + marketplace metadata
+
+## Local-first boundary
+
+- CLI and bundled Skills are the primary coding-harness surfaces.
+- MCP stdio is a secondary protocol adapter; it must not duplicate graph logic.
+- Graph state is local at `<repo>/.code-review-graph/graph.db` unless explicit
+  self-host/multi-user configuration changes the data directory.
+- CRG has no hosted Cloudflare runtime in the target topology; package, OCI,
+  CI, security, and release lifecycle remain active.
 
 ## Lenh thuong dung
 
@@ -52,16 +61,14 @@ Source files --> Tree-sitter parser --> SQLite graph (nodes + edges)
                                      NetworkX BFS --> Impact radius
                                           |
                                      Embedding store --> Semantic search
-                                          |
-                                     FastMCP server --> 7 tools (graph + query + review + config + security + help + config__open_relay)
+                                     FastMCP server --> secondary MCP adapter (7 tools: graph + query + review + config + security + help + config__open_relay)
 ```
 
 - **Parser** (parser.py): Tree-sitter extracts nodes (File, Class, Function, Type, Test) and edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON). Resolves same-file bare call targets to qualified names.
 - **Graph** (graph.py): SQLite with WAL mode. Multi-word AND-logic search. GraphNode/GraphEdge dataclasses.
 - **Incremental** (incremental.py): Git diff detection, file hash tracking, re-parses only changed files.
 - **Embeddings** (embeddings.py): Dual-mode -- local ONNX through the fastretrieval registry (default, zero-config) or cloud via the `EMBEDDING_MODELS` chain (litellm passthrough, `mcp_core.llm`; order = fallback, empty = local). Fixed 768-dim storage.
-- **Tools** (tools.py): Implementation layer for all graph operations. Output pagination via max_results.
-- **Server** (server.py): 7 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions/spot_check/renamed_in_diff/diff), review, config (status/set/cache_clear + setup_status/setup_start/setup_skip/setup_reset/setup_complete), security (scan/report/suppress/rule_list), help, config__open_relay (mcp-core relay helper). Returns JSON strings.
+- **Server** (server.py): 7 tools — graph (build/update/stats/embed/export/summarize), query (query/search/impact/large_functions/spot_check/renamed_in_diff/diff), review, config (status/set/cache_clear + setup_status/setup_start/setup_skip/setup_reset/setup_complete), security (scan/report/suppress/rule_list), help, config__open_relay (mcp-core relay helper). Returns structured dict payloads over MCP; the CLI serializes them as JSON.
 
 ## Embedding + LLM backends
 
@@ -150,8 +157,8 @@ chối, không tự rơi về model mặc định.
 
 ## Luu y quan trong
 
-- Lazy imports cho heavy deps (tree-sitter, fastretrieval, litellm via `mcp_core.llm`) -- tranh startup cost
-- MCP tools return error strings (`return "Error: ..."`) -- KHONG raise exceptions
+- Lazy imports cho heavy deps (tree-sitter, fastretrieval, litellm via `mcp_core.llm`, numpy) -- tranh startup cost
+- MCP tools return structured error payloads (`{"error": ...}`) and close local resources on every path.
 - GraphStore.upsert_edge takes EdgeInfo (fields: source, target), GraphEdge uses source_qualified/target_qualified
 - `_make_qualified()` builds qualified names as `file_path::name` or `file_path::parent.name`
 - Supported languages: Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++, Solidity

--- a/README.md
+++ b/README.md
@@ -76,9 +76,30 @@ v2.0 adds temporal columns (`valid_from_sha` / `valid_to_sha` on every node + ed
 
 ## Install
 
-The server runs over **stdio** by default and works with any MCP client. The
-recommended launcher is [`uvx`](https://docs.astral.sh/uv/) (no install step --
-it fetches and runs the published package in an isolated environment):
+For OMP and other local coding harnesses, the primary surface is the package CLI
+plus the bundled `skills/` workflows. The skills invoke the CLI directly and do
+not require an MCP server mapping.
+
+```bash
+# Run without a persistent install
+uvx --python 3.13 better-code-review-graph graph build --full-rebuild \
+  --repo-root /path/to/repo
+uvx --python 3.13 better-code-review-graph graph stats \
+  --repo-root /path/to/repo
+
+# Or install the console script
+pip install better-code-review-graph
+better-code-review-graph query search --search-query "authentication" \
+  --repo-root /path/to/repo
+```
+
+The optional Semgrep engine for deeper security scans is a separate extra:
+
+```bash
+pip install 'better-code-review-graph[security]'
+```
+
+MCP stdio remains a secondary protocol adapter for clients that require it:
 
 ```json
 {
@@ -92,26 +113,12 @@ it fetches and runs the published package in an isolated environment):
 }
 ```
 
-Or install it as a Python package:
-
-```bash
-uvx better-code-review-graph        # run without installing
-pip install better-code-review-graph
-```
-
-The optional Semgrep engine for deeper security scans is a separate extra:
-
-```bash
-pip install 'better-code-review-graph[security]'
-```
-
 **Install with an AI agent** -- paste this to your AI coding agent:
 
-> Install MCP server `better-code-review-graph` following the steps at
+> Install `better-code-review-graph` following the steps at
 > https://raw.githubusercontent.com/n24q02m/claude-plugins/main/plugins/better-code-review-graph/setup-with-agent.md
 
-Full per-client setup (Claude Code, Codex, Gemini CLI, Cursor, Windsurf, raw
-`mcp.json`) is at
+Full CLI usage is in [CLI](#cli). Optional per-client MCP setup is at
 **[mcp.n24q02m.com/servers/better-code-review-graph/setup/](https://mcp.n24q02m.com/servers/better-code-review-graph/setup/)**.
 
 ## Local-first boundary

--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ Full per-client setup (Claude Code, Codex, Gemini CLI, Cursor, Windsurf, raw
 `mcp.json`) is at
 **[mcp.n24q02m.com/servers/better-code-review-graph/setup/](https://mcp.n24q02m.com/servers/better-code-review-graph/setup/)**.
 
+## Local-first boundary
+
+CRG is local-first for coding workflows:
+
+- **CLI and bundled Skills are the primary surfaces** for graph build/query,
+  impact analysis, review context, security scans, and repository onboarding.
+- **MCP stdio is the secondary protocol adapter** over the same local domain
+  services; it does not maintain a separate graph implementation.
+- Graph state stays in `<repo>/.code-review-graph/graph.db` unless an explicit
+  multi-user/self-host configuration selects another data directory.
+- PyPI, OCI, CI, security scanning, and release maintenance remain active.
+  CRG has no hosted Cloudflare runtime in the target topology.
+
 ## Smithery
 
 The repo ships a [`smithery.yaml`](smithery.yaml) so the server can be built and
@@ -326,36 +339,47 @@ browser setup form (e.g. after credential expiry); in stdio mode it returns
 ## CLI
 
 Running `better-code-review-graph` with **no arguments** starts the MCP server
-over stdio (this is what an MCP client launches). A leading positional argument
-routes to a subcommand instead -- handy for building or embedding the graph
-directly from a shell or CI step, before any MCP client connects. Run these with
+over stdio. A leading positional argument routes to a local CLI subcommand
+that calls the same domain services used by the MCP adapter. Run these with
 `uvx` (or `uv run` from a source checkout):
 
 ```bash
 # Start the MCP server over stdio (default -- no subcommand)
 uvx better-code-review-graph
 
-# Build (or incrementally update) the graph for the current repo
+# Build, inspect, and embed the local graph
 uvx better-code-review-graph graph build
-
-# Full re-parse of every file instead of a git-diff incremental
-uvx better-code-review-graph graph build --full-rebuild
-
-# Compute embeddings for semantic search (local ONNX by default)
+uvx better-code-review-graph graph stats
 uvx better-code-review-graph graph embed
+
+# Query relationships and impact
+uvx better-code-review-graph query query \
+  --pattern callers_of --target "path/to/module.py::function"
+uvx better-code-review-graph query search --search-query "authentication"
+uvx better-code-review-graph query impact --changed-files src/app.py
+
+# Produce review context and run a local security scan
+uvx better-code-review-graph review context --base HEAD~1
+uvx better-code-review-graph security scan --engine heuristic
 ```
 
 | Command | Description |
 |:--------|:------------|
-| `graph build` | Full or incremental graph build. `--full-rebuild` re-parses every file; `--base <ref>` sets the git ref for the incremental diff (default `HEAD~1`); `--repo-root <path>` overrides the auto-detected repo root. |
-| `graph embed` | Compute vector embeddings for the current graph (local ONNX or the configured cloud chain). Accepts `--repo-root`. |
-| `config status` / `config delete` | Show or remove the stored credential config (`--yes` skips the delete confirmation). |
-| `doctor` | Environment self-check: Python version, credential backend, store-dir writability, config and relay state. |
-| `relay status` / `relay open` / `relay reset` | Inspect, open, or clear the browser relay setup session (HTTP mode). |
+| `graph build` | Full or incremental graph build. `--full-rebuild` re-parses every file; `--base <ref>` sets the incremental diff ref; `--repo-root <path>` overrides auto-detection. |
+| `graph embed` | Compute vector embeddings using local ONNX or the configured cloud chain. |
+| `graph stats` / `graph export` / `graph import` / `graph summarize` | Inspect, export/import a portable `crg` graph, or summarize functions. |
+| `query query` / `query search` | Run relationship patterns or keyword/semantic search. |
+| `query impact` / `query large_functions` | Analyze changed-file blast radius or find oversized nodes. |
+| `query spot_check` / `query renamed_in_diff` / `query diff` | Inspect callsites, line shifts, or commit-to-commit graph changes. |
+| `review context` / `review delta` | Generate review context or diff buckets for a code change. |
+| `security scan` / `security report` / `security suppress` / `security rule_list` | Run and manage heuristic/Semgrep security findings. |
+| `config status` / `config delete` | Show or remove stored credential config (`--yes` skips confirmation). |
+| `doctor` | Environment self-check from shared `mcp-core` CLI. |
+| `relay status` / `relay open` / `relay reset` | Inspect, open, or clear the relay setup session. |
 
-The `graph build` and `graph embed` subcommands print a JSON result and exit
-non-zero on error. The `config`, `doctor`, and `relay` subcommands come from the
-shared [mcp-core](https://github.com/n24q02m/mcp-core) CLI.
+CLI subcommands print structured JSON and exit non-zero on an error. The
+`config`, `doctor`, and `relay` subcommands come from shared `mcp-core`.
+
 
 ## Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "tree-sitter-language-pack>=1.13.3,<2",
     "networkx>=3.6.1,<4",
     "watchdog>=6.0.0,<7",
-    "fastretrieval>=1.0.1",
+    "fastretrieval>=1.1.0b1,<2",
     "httpx",
     "pydantic-settings",
     # Floor tracks the current mcp-core stable for cascade parity with

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/better-code-review-graph",
-  "description": "Token-efficient code review knowledge graph: semantic search and call-graph resolution.",
+  "description": "Knowledge graph for token-efficient code reviews -- semantic search and call-graph resolution across your codebase.",
   "repository": {
     "url": "https://github.com/n24q02m/better-code-review-graph.git",
     "source": "github"

--- a/skills/impact-audit/SKILL.md
+++ b/skills/impact-audit/SKILL.md
@@ -10,27 +10,30 @@ Scope a **planned** change before writing it. Answers "if I change this, what el
 
 Run this while the change is still a proposal. Once code is written, `review-delta` and `review-pr` review what actually changed.
 
-**Token optimization:** call `help(topic="query")` once for the actions reference rather than probing arguments by trial and error.
+**Command surface:** run the local CLI through the coding harness shell. Examples
+use the installed `better-code-review-graph` command; from a source checkout,
+prefix it with `uv run`. No MCP mapping is required. Use
+`better-code-review-graph query --help` for the actions reference.
 
 ## Steps
 
 1. **State the change under audit in one line** before querying anything -- for example "add a required `tenant_id` parameter to `create_session`". The audit is only meaningful against a specific proposed edit, because the risky part differs: adding a required parameter breaks callers, changing a return type breaks consumers, renaming breaks both plus anything resolving the name dynamically.
 
 2. **Make sure every repository that could be affected is in the graph.** A blast radius is only as wide as the graph:
-   - `config(action="status")` -- confirm the graph exists and note `files_count`.
-   - `graph(action="build", roots=["<path-a>", "<path-b>"])` -- federate the additional repositories into the same graph. Each root is registered and its files tagged with a `repo_id`.
+   - `better-code-review-graph graph stats --repo-root "<path-a>"` -- confirm the graph exists and note `files_count`.
+   - `better-code-review-graph graph build --full-rebuild --repo-root "<path-a>" --roots "<path-b>"` -- federate the additional repositories into the same graph. Each root is registered and its files tagged with a `repo_id`.
    - Without federation, a cross-repo audit will report a clean radius simply because the consumers were never indexed. Say so in the report rather than implying the change is contained.
 
-3. **Locate every definition of the symbol** with `query(action="search", search_query="<name>")`, leaving `repo` unset so the search spans all federated repositories. Two repositories may define the same name for unrelated purposes -- resolve which definition is actually the target before tracing, and note any same-named decoys so a later reader does not re-open the question.
+3. **Locate every definition of the symbol** with `better-code-review-graph query search --search-query "<name>" --repo-root "<path-a>"`, leaving `--repo` unset so the search spans all federated repositories. Two repositories may define the same name for unrelated purposes -- resolve which definition is actually the target before tracing, and note any same-named decoys so a later reader does not re-open the question.
 
 4. **Map direct consumers**, unscoped across the federation:
-   - `query(action="query", pattern="callers_of", target="<name>")` -- who calls it
-   - `query(action="query", pattern="importers_of", target="<file_path>")` -- which files import the module
-   - `query(action="query", pattern="inheritors_of", target="<name>")` and `children_of` when the target is a class -- subclasses inherit the change whether or not they call it
+   - `better-code-review-graph query query --pattern callers_of --target "<name>" --repo-root "<path-a>"` -- who calls it
+   - `better-code-review-graph query query --pattern importers_of --target "<file_path>" --repo-root "<path-a>"` -- which files import the module
+   - use `--pattern inheritors_of` and `--pattern children_of` when the target is a class -- subclasses inherit the change whether or not they call it
 
-5. **Measure the full radius** with `query(action="impact", changed_files=["<file>"], max_depth=2)`. Raise `max_depth` to 3 when step 4 shows the direct consumers are themselves widely used; leave it at 2 otherwise, since depth costs tokens and the tail is mostly noise.
+5. **Measure the full radius** with `better-code-review-graph query impact --changed-files "<file>" --max-depth 2 --repo-root "<path-a>"`. Raise `--max-depth` to 3 when step 4 shows the direct consumers are themselves widely used; leave it at 2 otherwise, since depth costs tokens and the tail is mostly noise.
 
-6. **Split the radius per repository.** Re-run the impact query with `repo="<repo_id>"` for each federated repository. The per-repo split is the deliverable: it converts "47 impacted files" into "3 repositories, one of which is published and consumed elsewhere", which is what determines release ordering.
+6. **Split the radius per repository.** Re-run the impact command with `--repo "<repo_id>"` for each federated repository. The per-repo split is the deliverable: it converts "47 impacted files" into "3 repositories, one of which is published and consumed elsewhere", which is what determines release ordering.
 
 7. **Call out the boundaries the graph cannot cross.** Call and import edges are resolved per language (Python, TypeScript, Go, Java, Rust, plus a generic fallback). Edges do **not** exist for:
    - calls that cross a network boundary (HTTP route, RPC, queue message)
@@ -39,7 +42,7 @@ Run this while the change is still a proposal. Once code is written, `review-del
 
    These are exactly the places a cross-repo change breaks silently. List them as unverified rather than reporting a radius that looks complete.
 
-8. **Check the radius is tested** with `query(action="query", pattern="tests_for", target="<name>")` for the target and its direct consumers. An impacted call site with no test is a site that will not tell you when the change is wrong.
+8. **Check the radius is tested** with `better-code-review-graph query query --pattern tests_for --target "<name>" --repo-root "<path-a>"` for the target and its direct consumers. An impacted call site with no test is a site that will not tell you when the change is wrong.
 
 9. **Report**:
 

--- a/skills/onboard-repo/SKILL.md
+++ b/skills/onboard-repo/SKILL.md
@@ -10,39 +10,41 @@ Take a codebase you have never seen and turn it into a queryable graph, then rea
 
 **Scope:** this skill builds and reads a knowledge graph. It does not modify source files, CI configuration, or project conventions. The only files it creates are the graph database under `.code-review-graph/` (already self-ignored) and, when you choose to add one, a `.code-review-graphignore`.
 
+**Command surface:** run the local CLI through the coding harness shell. Examples
+use the installed `better-code-review-graph` command; from a source checkout,
+prefix it with `uv run`. No MCP mapping is required.
+
 ## Steps
 
-1. **Check what already exists** by calling `config(action="status")`. It returns `graph_path`, `total_nodes`, `total_edges`, `files_count`, `languages`, `embedding_backend`, `embeddings_count`, and `last_updated`.
-   - `total_nodes > 0` means a graph is already built -- skip to step 5 instead of rebuilding.
-   - `graph_path: null` or a missing status means no graph yet -- continue.
+1. **Check what already exists** with `better-code-review-graph graph stats --repo-root "<path>"`. A non-empty graph can go directly to step 5; a missing-graph error means continue with a build.
 
 2. **Decide the indexing scope before building**:
-   - Single repository: no extra arguments needed.
+   - Single repository: pass only `--repo-root "<path>"`.
    - A repository that vendors or embeds others: add a `.code-review-graphignore` at the repo root (one `fnmatch` pattern per line, `#` for comments) so vendored trees, build output, and fixtures do not inflate the graph. Common additions: `vendor/*`, `third_party/*`, `**/generated/*`, `**/*.min.js`.
-   - Several sibling repositories that call each other: federate them in one graph with the `roots` argument in step 3, then use `impact-audit` for cross-repo questions.
+   - Several sibling repositories that call each other: federate them in one graph with `--roots` in step 3, then use `impact-audit` for cross-repo questions.
 
-3. **Build the graph** by calling `graph(action="build")`.
-   - For a federated build: `graph(action="build", roots=["<path-a>", "<path-b>"])`. Each root is registered in the repo registry and its files are tagged with a `repo_id`, which later lets you scope any query with `repo="<repo_id>"`.
+3. **Build the graph** with `better-code-review-graph graph build --full-rebuild --repo-root "<path>"`.
+   - For a federated build: `better-code-review-graph graph build --full-rebuild --repo-root "<path-a>" --roots "<path-b>"`. Each root is registered in the repo registry and its files are tagged with a `repo_id`, which later lets you scope any query with `--repo "<repo_id>"`.
    - Parsing is Tree-sitter based and needs no language servers, toolchains, or compilation -- an unbuildable checkout still indexes.
 
-4. **Enable semantic search** by calling `graph(action="embed")`. Without embeddings, `query(action="search")` falls back to name and keyword matching, which will miss "where is authentication handled" style questions.
-   - The default backend is local and requires no credentials. `config(action="status")` reports which backend resolved under `embedding_backend`.
-   - If a cloud embedding chain is expected but `embedding_backend` shows local, check `config(action="setup_status")` before assuming the model list is wrong.
-   - Optional: `graph(action="summarize")` adds generated summaries for function nodes, but only when a summarizer model chain is configured. It is a no-op otherwise -- do not report it as a failure.
+4. **Enable semantic search** with `better-code-review-graph graph embed --repo-root "<path>"`. Without embeddings, the CLI's search action falls back to name and keyword matching, which will miss "where is authentication handled" style questions.
+   - The default backend is local and requires no credentials. The graph-stats result reports the resolved backend and embedding count.
+   - If a cloud embedding chain is expected but stats show local, inspect the local environment/configuration rather than assuming the model list is wrong.
+   - Optional: `better-code-review-graph graph summarize --repo-root "<path>"` adds generated summaries for function nodes, but only when a summarizer model chain is configured. It is a no-op otherwise -- do not report it as a failure.
 
-5. **Read the shape of the codebase** by calling `graph(action="stats")`. Record the language mix, file count, and node/edge counts. The language mix decides which conventions to expect in later steps -- do not assume the dominant language from the repository name.
+5. **Read the shape of the codebase** with `better-code-review-graph graph stats --repo-root "<path>"`. Record the language mix, file count, and node/edge counts. The language mix decides which conventions to expect in later steps -- do not assume the dominant language from the repository name.
 
-6. **Locate the entry points**. Use `query(action="search", search_query=...)` with terms that suit the language mix -- `main`, `cli`, `handler`, `route`, `server`, `worker`, `command`. Then confirm each candidate is genuinely an entry point by checking it has few or no callers:
-   - `query(action="query", pattern="callers_of", target="<name>")` -- an entry point is typically called by nothing inside the repo.
+6. **Locate the entry points**. Use `better-code-review-graph query search --search-query "<term>" --repo-root "<path>"` with terms that suit the language mix -- `main`, `cli`, `handler`, `route`, `server`, `worker`, `command`. Then confirm each candidate is genuinely an entry point by checking it has few or no callers:
+   - `better-code-review-graph query query --pattern callers_of --target "<name>" --repo-root "<path>"` -- an entry point is typically called by nothing inside the repo.
 
 7. **Find the load-bearing modules** -- the files everything else depends on:
-   - `query(action="query", pattern="importers_of", target="<file_path>")` for candidate core files; the ones with the most importers are where a newcomer should start reading.
-   - `query(action="query", pattern="file_summary", target="<file_path>")` for a structural digest of a file without reading it in full.
+   - use `better-code-review-graph query query --pattern importers_of --target "<file_path>" --repo-root "<path>"` for candidate core files; the ones with the most importers are where a newcomer should start reading.
+   - use `better-code-review-graph query query --pattern file_summary --target "<file_path>" --repo-root "<path>"` for a structural digest of a file without reading it in full.
 
-8. **Trace one representative flow end to end.** Pick a single entry point from step 6 and walk outward with `query(action="query", pattern="callees_of", target="<name>")`, two or three hops deep. One traced flow teaches the layering faster than reading ten files.
+8. **Trace one representative flow end to end.** Pick a single entry point from step 6 and walk outward with `better-code-review-graph query query --pattern callees_of --target "<name>" --repo-root "<path>"`, two or three hops deep. One traced flow teaches the layering faster than reading ten files.
 
 9. **Check the test topology**:
-   - `query(action="query", pattern="tests_for", target="<name>")` on the core modules from step 7.
+   - run `better-code-review-graph query query --pattern tests_for --target "<name>" --repo-root "<path>"` on the core modules from step 7.
    - Modules with many importers and no tests are the risky parts of the codebase, and worth stating explicitly in the report.
 
 10. **Report the orientation map**:

--- a/skills/refactor-check/SKILL.md
+++ b/skills/refactor-check/SKILL.md
@@ -8,18 +8,22 @@ argument-hint: "<function or class name> [intended change]"
 
 Analyze whether a refactoring is safe BEFORE making changes. Produces a verdict with specific risks and mitigation steps.
 
+**Command surface:** run the local CLI through the coding harness shell. Examples
+use the installed `better-code-review-graph` command; from a source checkout,
+prefix it with `uv run`. No MCP mapping is required.
+
 ## Steps
 
 1. **Get the full dependency graph** for the target:
-   - `graph(action="update")` to ensure graph is current
-   - `query(action="query", pattern="callers_of", target="<name>")` -- who calls this
-   - `query(action="query", pattern="callees_of", target="<name>")` -- what this calls
-   - `query(action="query", pattern="imports_of", target="<name>")` -- what this imports
-   - If it is a class: `query(action="query", pattern="inheritors_of", target="<name>")` and `query(action="query", pattern="children_of", target="<name>")`
+   - `better-code-review-graph graph build --base HEAD --repo-root "<path>"` to index current working changes
+   - `better-code-review-graph query query --pattern callers_of --target "<name>" --repo-root "<path>"` -- who calls this
+   - use `--pattern callees_of` to see what this calls
+   - use `--pattern imports_of` to see what this imports
+   - If it is a class, also query `--pattern inheritors_of` and `--pattern children_of`
 
 2. **Identify test coverage**:
-   - `query(action="query", pattern="tests_for", target="<name>")` -- direct tests
-   - For each caller, also check `tests_for` to see if callers have integration tests covering this function indirectly
+   - `better-code-review-graph query query --pattern tests_for --target "<name>" --repo-root "<path>"` -- direct tests
+   - For each caller, also query `tests_for` to see if callers have integration tests covering this function indirectly
    - Record: number of direct tests, number of callers with tests, number of callers without tests
 
 3. **Flag public API exposure**:
@@ -29,7 +33,7 @@ Analyze whether a refactoring is safe BEFORE making changes. Produces a verdict 
    - Public API = any function/class importable by external consumers
 
 4. **Estimate blast radius**:
-   - `query(action="impact", target="<name>")` -- full impact analysis
+   - `better-code-review-graph query impact --changed-files "<target-file>" --repo-root "<path>"` -- file-level impact analysis around the target
    - Count: total impacted files, total impacted functions, depth of dependency chain
    - Identify any impacted files outside the immediate package/module
 

--- a/skills/review-delta/SKILL.md
+++ b/skills/review-delta/SKILL.md
@@ -8,19 +8,22 @@ argument-hint: "[file or function name]"
 
 Perform a focused, token-efficient code review of uncommitted changes and their blast radius. Use this for quick local reviews BEFORE committing. For full branch/PR reviews, use review-pr instead.
 
-**Token optimization:** Before starting, call `help(topic="graph")` for the full actions reference. Use ONLY changed nodes + 2-hop neighbors in context.
+**Command surface:** run the local CLI through the coding harness shell. Examples
+use the installed `better-code-review-graph` command; from a source checkout,
+prefix it with `uv run`. No MCP mapping is required. Use
+`better-code-review-graph review --help` for the command reference.
 
 ## Steps
 
-1. **Ensure the graph is current** by calling `graph(action="update")`.
+1. **Ensure the graph is current** with `better-code-review-graph graph build --base HEAD --repo-root "<path>"`.
 
-2. **Get review context** by calling `review()`. This returns:
+2. **Get review context** with `better-code-review-graph review context --base HEAD --repo-root "<path>"`. This returns:
    - Changed files (auto-detected from git diff)
    - Impacted nodes and files (blast radius)
    - Source code snippets for changed areas
    - Review guidance (test coverage gaps, wide impact warnings, inheritance concerns)
 
-3. **Analyze the blast radius** by reviewing the `impacted_nodes` and `impacted_files` in the context. Focus on:
+3. **Analyze the blast radius** by reviewing the `impacted_nodes` and `impacted_files` in the JSON result. Focus on:
    - Functions whose callers changed (may need signature/behavior verification)
    - Classes with inheritance changes (Liskov substitution concerns)
    - Files with many dependents (high-risk changes)
@@ -28,7 +31,7 @@ Perform a focused, token-efficient code review of uncommitted changes and their 
 4. **Perform the review** using the context. For each changed file:
    - Review the source snippet for correctness, style, and potential bugs
    - Check if impacted callers/dependents need updates
-   - Verify test coverage using `query(action="query", pattern="tests_for", target=<function_name>)`
+   - Verify test coverage with `better-code-review-graph query query --pattern tests_for --target "<function>" --repo-root "<path>"`
    - Flag any untested changed functions
 
 5. **Report findings** in a structured format:

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -8,7 +8,11 @@ argument-hint: "[PR number or branch name]"
 
 Comprehensive code review of a pull request or branch diff against its base. Unlike review-delta (quick review of uncommitted local changes), this reviews ALL commits in a branch for PR submission readiness.
 
-**Token optimization:** Before starting, call `help(topic="graph")` for the full actions reference. Never include full files unless explicitly asked.
+**Command surface:** run the local CLI through the coding harness shell. Examples
+use the installed `better-code-review-graph` command; from a source checkout,
+prefix it with `uv run`. No MCP mapping is required. Use
+`better-code-review-graph review --help` for the command reference. Never
+include full files unless explicitly asked.
 
 ## Steps
 
@@ -16,7 +20,7 @@ Comprehensive code review of a pull request or branch diff against its base. Unl
    - If a PR number or branch is provided, use `git diff main...<branch>` to get changed files
    - Otherwise auto-detect from the current branch vs main/master
 
-2. **Update the graph** by calling `graph(action="build", base="main")` to ensure the graph reflects the current state.
+2. **Update the graph** with `better-code-review-graph graph build --base main --repo-root "<path>"` so it reflects the current branch.
 
 3. **Commit-by-commit analysis** (for PRs with >3 commits):
    - `git log --oneline main..HEAD` to list all commits
@@ -24,23 +28,23 @@ Comprehensive code review of a pull request or branch diff against its base. Unl
    - Verify each commit message follows Conventional Commits (`type(scope): description`)
    - Flag commits that mix unrelated changes
 
-4. **Get the full review context** by calling `review(base="main")`:
+4. **Get the full review context** with `better-code-review-graph review context --base main --repo-root "<path>"`:
    - Returns all changed files across all commits in the PR
    - Includes impacted nodes and blast radius
 
-5. **Analyze impact** by calling `query(action="impact", base="main")`:
+5. **Analyze impact** with `better-code-review-graph query impact --base main --repo-root "<path>"`:
    - Review the blast radius across the entire PR
    - Identify high-risk areas (widely depended-upon code)
 
 6. **Breaking change detection** for public APIs:
    - Identify exported/public functions, classes, types that changed
    - Check for: removed parameters, changed return types, renamed exports, removed functions
-   - Use `query(action="query", pattern="callers_of", target=<func>)` to find all consumers
+   - Use `better-code-review-graph query query --pattern callers_of --target "<function>" --repo-root "<path>"` to find all consumers
    - Flag any change where callers outside the PR would break
 
 7. **Deep-dive each changed file**:
    - Read the full source of files with significant changes
-   - Use `query(action="query", pattern="tests_for", target=<func>)` to verify test coverage
+   - Use `better-code-review-graph query query --pattern tests_for --target "<function>" --repo-root "<path>"` to verify test coverage
    - Check for untested new functions
 
 8. **Generate structured review output**:
@@ -87,5 +91,5 @@ Comprehensive code review of a pull request or branch diff against its base. Unl
 ## Tips
 
 - For large PRs (>10 files), focus on the highest-impact files first (most dependents)
-- Use `query(action="search", search_query=<term>)` to find related code the PR might have missed
+- Use `better-code-review-graph query search --search-query "<term>" --repo-root "<path>"` to find related code the PR might have missed
 - Check if renamed/moved functions have updated all callers

--- a/skills/security-sweep/SKILL.md
+++ b/skills/security-sweep/SKILL.md
@@ -8,34 +8,38 @@ argument-hint: "[path, rule id, or severity floor]"
 
 Scan the codebase for dangerous constructs, then use the graph to answer the question a flat scanner cannot: **can untrusted input actually reach this?** A medium-severity finding in a request handler outranks a critical one in dead code, and only the call graph can tell them apart.
 
+**Command surface:** run the local CLI through the coding harness shell. Examples
+use the installed `better-code-review-graph` command; from a source checkout,
+prefix it with `uv run`. No MCP mapping is required.
+
 ## Steps
 
-1. **Make the graph current** by calling `graph(action="update")`. Findings are attached to graph nodes, so anything unindexed is unscanned.
+1. **Make the graph current** with `better-code-review-graph graph build --base HEAD --repo-root "<path>"`. Findings are attached to graph nodes, so anything unindexed is unscanned.
 
-2. **Read the active ruleset** with `security(action="rule_list", engine="heuristic")` before scanning, and check which languages each rule declares. This determines what a clean result is worth -- see Coverage Limits below.
+2. **Read the active ruleset** with `better-code-review-graph security rule_list --engine heuristic` before scanning, and check which languages each rule declares. This determines what a clean result is worth -- see Coverage Limits below.
 
-3. **Run the Tier 1 scan**: `security(action="scan", engine="heuristic")`. It returns `total`, `by_severity`, `by_rule`, `tags_by_node`, and `suppressed_count`. Tier 1 is regex matching over the source of function, class, and method nodes -- fast, no external tool, no data-flow analysis.
+3. **Run the Tier 1 scan**: `better-code-review-graph security scan --engine heuristic --repo-root "<path>"`. It returns `total`, `by_severity`, `by_rule`, `tags_by_node`, and `suppressed_count`. Tier 1 is regex matching over the source of function, class, and method nodes -- fast, no external tool, no data-flow analysis.
 
-4. **Run Tier 2 when it is available**: `security(action="scan", engine="semgrep")`. Semgrep is an opt-in extra and is not installed by default.
-   - When the CLI is missing the call returns `{"error": ..., "engine": "semgrep"}`.
+4. **Run Tier 2 when it is available**: `better-code-review-graph security scan --engine semgrep --repo-root "<path>"`. Semgrep is an opt-in extra and is not installed by default.
+   - When the CLI is missing the command returns `{"error": ..., "engine": "semgrep"}` with a non-zero exit.
    - Treat that as **not run**, never as **clean**. Report Tier 2 as unavailable instead of silently reporting Tier 1 numbers as the whole picture.
 
 5. **Rank findings by reachability** -- the step that makes this a graph sweep rather than a grep. For each tagged node, walk backwards toward the entry points:
-   - `query(action="query", pattern="callers_of", target="<node>")`
+   - `better-code-review-graph query query --pattern callers_of --target "<node>" --repo-root "<path>"`
    - Repeat on the callers, two or three hops, until you reach either an entry point (route handler, CLI command, worker, event consumer) or nothing.
    - A node with no callers is either dead code or an entry point itself. Distinguish the two before ranking: an unreferenced HTTP handler is the *most* exposed code in the repository, not the least.
 
 6. **Confirm the source-to-sink path before filing anything.** Tier 1 matches text, not data flow, so a match proves a dangerous construct exists, not that untrusted input reaches it. For each candidate:
    - Read the matched line and the parameters of the enclosing function.
    - Establish where the tainted value originates. A `subprocess` call built from a hardcoded constant is not an injection; the same call built from a request field is.
-   - `query(action="query", pattern="callees_of", target="<node>")` helps confirm what the function actually invokes when the match is ambiguous.
+   - use `better-code-review-graph query query --pattern callees_of --target "<node>" --repo-root "<path>"` to confirm what the function actually invokes when the match is ambiguous.
 
 7. **Triage the residue into suppressions.** For rules that are structurally inapplicable to this codebase, or findings confirmed as false positives:
-   - `security(action="suppress", rule_id="<rule_id>")` -- persists to `.code-review-graph/security-suppressions.json`
-   - `security(action="suppress", rule_id="<rule_id>", remove=true)` -- reverses it
+   - `better-code-review-graph security suppress --rule-id "<rule_id>" --repo-root "<path>"` -- persists to `.code-review-graph/security-suppressions.json`
+   - add `--remove` to reverse a suppression
    - Suppression is per rule, not per finding, so suppressing a rule hides every current and future match. Record the justification in the report; a suppressed rule that later becomes relevant is a silent regression.
 
-8. **Export when the result feeds another system**: `security(action="report", format="sarif")` returns SARIF v2.1.0 for code-scanning ingestion; `format="json"` re-emits the cached payload. Both replay the last scan rather than rescanning.
+8. **Export when the result feeds another system**: `better-code-review-graph security report --format sarif --repo-root "<path>"` returns SARIF v2.1.0; use `--format json` to re-emit the cached payload. Both replay the last scan rather than rescanning.
 
 9. **Report**:
 

--- a/src/better_code_review_graph/cli.py
+++ b/src/better_code_review_graph/cli.py
@@ -2,7 +2,7 @@
 
 Bare invocation and any leading-dash argv (e.g. --http) start the server
 exactly as before; a leading positional argv[0] routes to a subcommand
-(``graph build|embed``) instead.
+(``graph``, ``query``, ``review``, ``security``, etc.) instead.
 """
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ import argparse
 import json
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
+from typing import Any
 
 
 def _version() -> str:
@@ -28,15 +29,27 @@ def _serve(argv: list[str]) -> int | None:
     return 0
 
 
+def _print_result(result: dict[str, Any]) -> int:
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 1 if "error" in result else 0
+
+
+# ---------------------------------------------------------------------------
+# 1. graph subcommand
+# ---------------------------------------------------------------------------
+
+
 def _configure_graph(p: argparse.ArgumentParser) -> None:
     p.add_argument(
-        "graph_action", choices=["build", "embed"], help="Graph action to run"
+        "graph_action",
+        choices=["build", "embed", "stats", "export", "import", "summarize"],
+        help="Graph action to run",
     )
     p.add_argument(
         "--full-rebuild",
         action="store_true",
         default=False,
-        help="Re-parse every file (build only; ignored for embed)",
+        help="Re-parse every file (build only)",
     )
     p.add_argument(
         "--repo-root",
@@ -46,26 +59,463 @@ def _configure_graph(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--base",
         default="HEAD~1",
-        help="Git ref for incremental diff (build only; ignored for embed)",
+        help="Git ref for incremental diff (build only)",
+    )
+    p.add_argument(
+        "--roots",
+        nargs="*",
+        default=None,
+        help="Additional repository root paths for federated build",
+    )
+    p.add_argument(
+        "--format",
+        choices=["graphml", "json-ld", "dot", "cypher", "crg"],
+        default="graphml",
+        help="Export format (export only)",
+    )
+    p.add_argument(
+        "--output-path",
+        default=None,
+        help="Output file path for export",
+    )
+    p.add_argument(
+        "--input-path",
+        default="",
+        help="Input file path for import",
+    )
+    p.add_argument(
+        "--max-nodes",
+        type=int,
+        default=500,
+        help="Maximum functions to summarize (summarize only)",
     )
 
 
 def _handle_graph(args: argparse.Namespace) -> int:
-    if args.graph_action == "build":
-        from .tools import build_or_update_graph
+    from .tools import (
+        build_or_update_graph,
+        embed_graph,
+        export_graph_dispatch,
+        import_graph_dispatch,
+        list_graph_stats,
+        summarize_graph_dispatch,
+    )
 
-        result = build_or_update_graph(
-            full_rebuild=args.full_rebuild,
-            repo_root=args.repo_root,
-            base=args.base,
-        )
-    else:
-        from .tools import embed_graph
-
+    action = args.graph_action
+    if action == "build":
+        kwargs: dict[str, Any] = {
+            "full_rebuild": args.full_rebuild,
+            "repo_root": args.repo_root,
+            "base": args.base,
+        }
+        if args.roots is not None:
+            kwargs["roots"] = args.roots
+        result = build_or_update_graph(**kwargs)
+    elif action == "embed":
         result = embed_graph(repo_root=args.repo_root)
+    elif action == "stats":
+        result = list_graph_stats(repo_root=args.repo_root)
+    elif action == "export":
+        result = export_graph_dispatch(
+            format=args.format,
+            output_path=args.output_path,
+            repo_root=args.repo_root,
+        )
+    elif action == "import":
+        result = import_graph_dispatch(
+            import_path=args.input_path,
+            repo_root=args.repo_root,
+        )
+    elif action == "summarize":
+        result = summarize_graph_dispatch(
+            repo_root=args.repo_root,
+            max_nodes=args.max_nodes,
+        )
+    else:  # pragma: no cover
+        result = {"error": f"Unknown graph action: {action}"}
 
-    print(json.dumps(result, ensure_ascii=False, indent=2))
-    return 1 if "error" in result else 0
+    return _print_result(result)
+
+
+# ---------------------------------------------------------------------------
+# 2. query subcommand
+# ---------------------------------------------------------------------------
+
+
+def _configure_query(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "query_action",
+        choices=[
+            "query",
+            "search",
+            "impact",
+            "large_functions",
+            "spot_check",
+            "renamed_in_diff",
+            "diff",
+        ],
+        help="Query action to run",
+    )
+    p.add_argument(
+        "--pattern",
+        default="callers_of",
+        choices=[
+            "callers_of",
+            "callees_of",
+            "imports_of",
+            "importers_of",
+            "children_of",
+            "tests_for",
+            "inheritors_of",
+            "file_summary",
+        ],
+        help="Query pattern (for query action)",
+    )
+    p.add_argument(
+        "--target",
+        default="",
+        help="Target symbol or file path for query action",
+    )
+    p.add_argument(
+        "--search-query",
+        default="",
+        help="Search text or symbol name for search action",
+    )
+    p.add_argument(
+        "--changed-files",
+        nargs="*",
+        default=None,
+        help="Changed file paths for impact analysis",
+    )
+    p.add_argument(
+        "--max-results",
+        type=int,
+        default=500,
+        help="Maximum impact results",
+    )
+    p.add_argument(
+        "--max-payload-bytes",
+        type=int,
+        default=500_000,
+        help="Soft impact response-size cap",
+    )
+    p.add_argument(
+        "--base",
+        default="HEAD~1",
+        help="Git base ref for impact/renamed_in_diff",
+    )
+    p.add_argument(
+        "--from-sha",
+        default="",
+        help="Base commit SHA for graph diff",
+    )
+    p.add_argument(
+        "--to-sha",
+        default="",
+        help="Target commit SHA for graph diff",
+    )
+    p.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repository root path",
+    )
+    p.add_argument(
+        "--max-depth",
+        type=int,
+        default=2,
+        help="Maximum traversal depth",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Result count ceiling",
+    )
+    p.add_argument(
+        "--kind",
+        default=None,
+        help="Filter by node kind (function, class, file, etc.)",
+    )
+    p.add_argument(
+        "--min-lines",
+        type=int,
+        default=50,
+        help="Line count threshold for large_functions",
+    )
+    p.add_argument(
+        "--file-path-pattern",
+        default=None,
+        help="Filter large functions by file path substring",
+    )
+    p.add_argument(
+        "--n",
+        type=int,
+        default=5,
+        help="Number of random callsites for spot_check",
+    )
+    p.add_argument(
+        "--context-lines",
+        type=int,
+        default=2,
+        help="Source lines around spot-check callsites",
+    )
+    p.add_argument(
+        "--repo",
+        default="",
+        help="Scope query to a specific federated repo_id",
+    )
+    p.add_argument(
+        "--languages",
+        nargs="*",
+        default=None,
+        help="Filter by programming language(s)",
+    )
+    p.add_argument(
+        "--as-of",
+        default="",
+        help="Temporal commit SHA",
+    )
+
+
+def _handle_query(args: argparse.Namespace) -> int:
+    from .tools import (
+        diff_graph,
+        find_large_functions,
+        get_impact_radius,
+        query_graph,
+        renamed_in_diff,
+        semantic_search_nodes,
+        spot_check_last_callers,
+    )
+
+    action = args.query_action
+    if action == "query":
+        result = query_graph(
+            pattern=args.pattern,
+            target=args.target,
+            repo_root=args.repo_root,
+            repo=args.repo,
+            languages=args.languages,
+            as_of=args.as_of,
+        )
+    elif action == "search":
+        limit = args.limit if args.limit is not None else 20
+        result = semantic_search_nodes(
+            query=args.search_query,
+            repo_root=args.repo_root,
+            limit=limit,
+            kind=args.kind,
+            repo=args.repo,
+            as_of=args.as_of,
+        )
+    elif action == "impact":
+        result = get_impact_radius(
+            changed_files=args.changed_files,
+            base=args.base,
+            repo_root=args.repo_root,
+            max_depth=args.max_depth,
+            max_results=args.max_results,
+            max_payload_bytes=args.max_payload_bytes,
+            repo=args.repo,
+            as_of=args.as_of,
+        )
+    elif action == "large_functions":
+        limit = args.limit if args.limit is not None else 50
+        kind = args.kind if args.kind is not None else "function"
+        result = find_large_functions(
+            min_lines=args.min_lines,
+            kind=kind,
+            file_path_pattern=args.file_path_pattern,
+            repo_root=args.repo_root,
+            limit=limit,
+            repo=args.repo,
+        )
+    elif action == "spot_check":
+        result = spot_check_last_callers(
+            n=args.n,
+            repo_root=args.repo_root,
+            context_lines=args.context_lines,
+        )
+    elif action == "renamed_in_diff":
+        base = args.base if args.base is not None else "HEAD~1"
+        result = renamed_in_diff(
+            base=base,
+            repo_root=args.repo_root,
+        )
+    elif action == "diff":
+        result = diff_graph(
+            from_sha=args.from_sha,
+            to_sha=args.to_sha,
+            repo_root=args.repo_root,
+            repo=args.repo,
+        )
+    else:  # pragma: no cover
+        result = {"error": f"Unknown query action: {action}"}
+
+    return _print_result(result)
+
+
+# ---------------------------------------------------------------------------
+# 3. review subcommand
+# ---------------------------------------------------------------------------
+
+
+def _configure_review(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "review_action",
+        choices=["context", "delta"],
+        help="Review action to run",
+    )
+    p.add_argument(
+        "--changed-files",
+        nargs="*",
+        default=None,
+        help="Changed file paths for review context",
+    )
+    p.add_argument(
+        "--base",
+        default="HEAD~1",
+        help="Git base ref for review context",
+    )
+    p.add_argument(
+        "--from-sha",
+        default="",
+        help="Base commit SHA for review delta",
+    )
+    p.add_argument(
+        "--to-sha",
+        default="",
+        help="Target commit SHA for review delta",
+    )
+    p.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repository root path",
+    )
+    p.add_argument(
+        "--max-depth",
+        type=int,
+        default=2,
+        help="Maximum traversal depth",
+    )
+    p.add_argument(
+        "--repo",
+        default="",
+        help="Scope to a specific federated repo_id",
+    )
+    p.add_argument(
+        "--languages",
+        nargs="*",
+        default=None,
+        help="Filter by programming language(s)",
+    )
+
+
+def _handle_review(args: argparse.Namespace) -> int:
+    from .tools import get_review_context, review_delta
+
+    action = args.review_action
+    if action == "context":
+        result = get_review_context(
+            changed_files=args.changed_files,
+            base=args.base,
+            repo_root=args.repo_root,
+            max_depth=args.max_depth,
+            repo=args.repo,
+            languages=args.languages,
+        )
+    elif action == "delta":
+        result = review_delta(
+            from_sha=args.from_sha,
+            to_sha=args.to_sha,
+            repo_root=args.repo_root,
+            repo=args.repo,
+        )
+    else:  # pragma: no cover
+        result = {"error": f"Unknown review action: {action}"}
+
+    return _print_result(result)
+
+
+# ---------------------------------------------------------------------------
+# 4. security subcommand
+# ---------------------------------------------------------------------------
+
+
+def _configure_security(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "security_action",
+        choices=["scan", "report", "suppress", "rule_list"],
+        help="Security action to run",
+    )
+    p.add_argument(
+        "--engine",
+        choices=["heuristic", "semgrep"],
+        default="heuristic",
+        help="Security scanning engine",
+    )
+    p.add_argument(
+        "--format",
+        choices=["json", "sarif"],
+        default="json",
+        help="Security report format",
+    )
+    p.add_argument(
+        "--rule-id",
+        default="",
+        help="Rule ID to suppress or un-suppress",
+    )
+    p.add_argument(
+        "--remove",
+        action="store_true",
+        default=False,
+        help="Remove rule from suppression list instead of adding",
+    )
+    p.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repository root path",
+    )
+
+
+def _handle_security(args: argparse.Namespace) -> int:
+    from .tools import (
+        security_report,
+        security_rule_list,
+        security_scan,
+        security_suppress,
+    )
+
+    action = args.security_action
+    if action == "scan":
+        result = security_scan(
+            engine=args.engine,
+            repo_root=args.repo_root,
+        )
+    elif action == "report":
+        result = security_report(
+            format=args.format,
+            repo_root=args.repo_root,
+        )
+    elif action == "suppress":
+        result = security_suppress(
+            rule_id=args.rule_id,
+            remove=args.remove,
+            repo_root=args.repo_root,
+        )
+    elif action == "rule_list":
+        result = security_rule_list(
+            engine=args.engine,
+        )
+    else:  # pragma: no cover
+        result = {"error": f"Unknown security action: {action}"}
+
+    return _print_result(result)
+
+
+# ---------------------------------------------------------------------------
+# Main entrypoint
+# ---------------------------------------------------------------------------
 
 
 def main() -> int:
@@ -74,6 +524,15 @@ def main() -> int:
     return build_cli(
         "better-code-review-graph",
         serve=_serve,
-        extra={"graph": (_configure_graph, _handle_graph)},
+        extra={
+            "graph": (_configure_graph, _handle_graph),
+            "query": (_configure_query, _handle_query),
+            "review": (_configure_review, _handle_review),
+            "security": (_configure_security, _handle_security),
+        },
         version=_version(),
     )(None)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -468,3 +468,14 @@ def test_bundled_skills_use_local_cli_without_mcp_tool_calls():
         assert "better-code-review-graph" in content, skill_file
         assert not mcp_call.findall(content), skill_file
         assert not bare_subcommand.findall(content), skill_file
+
+
+def test_readme_installs_local_cli_before_optional_mcp_adapter():
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text(
+        encoding="utf-8"
+    )
+
+    local_cli = readme.index("For OMP and other local coding harnesses")
+    optional_mcp = readme.index("MCP stdio remains a secondary protocol adapter")
+    assert local_cli < optional_mcp
+    assert re.search(r"do\s+not require an MCP server mapping", readme)

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -10,7 +10,9 @@ Tests cover:
 from __future__ import annotations
 
 import json
+import re
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 from better_code_review_graph.cli import main
@@ -452,3 +454,17 @@ class TestCLISecurityContract:
 
         assert rc == 1
         assert "Repository not found" in capsys.readouterr().out
+
+
+def test_bundled_skills_use_local_cli_without_mcp_tool_calls():
+    skills_root = Path(__file__).resolve().parents[1] / "skills"
+    skill_files = sorted(skills_root.glob("*/SKILL.md"))
+
+    assert len(skill_files) == 6
+    mcp_call = re.compile(r"`(?:graph|query|review|security|help)\([^`]*\)`")
+    bare_subcommand = re.compile(r"`(?:graph|query|review|security|config)\s")
+    for skill_file in skill_files:
+        content = skill_file.read_text(encoding="utf-8")
+        assert "better-code-review-graph" in content, skill_file
+        assert not mcp_call.findall(content), skill_file
+        assert not bare_subcommand.findall(content), skill_file

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -1,0 +1,454 @@
+"""CLI contract tests verifying local-first CLI subcommands for CRG.
+
+Tests cover:
+- graph (build, embed, stats, export, import, summarize)
+- query (query, search, impact, large_functions, spot_check, renamed_in_diff, diff)
+- review (context, delta)
+- security (scan, report, suppress, rule_list)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import patch
+
+from better_code_review_graph.cli import main
+
+
+class TestCLIGraphContract:
+    def test_cli_graph_stats(self, capsys):
+        payload = {
+            "status": "ok",
+            "total_nodes": 42,
+            "total_edges": 84,
+            "files_count": 5,
+        }
+        with (
+            patch(
+                "better_code_review_graph.tools.list_graph_stats", return_value=payload
+            ) as mock_stats,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "graph",
+                    "stats",
+                    "--repo-root",
+                    "/tmp/repo",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_stats.assert_called_once_with(repo_root="/tmp/repo")
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert json.loads(out) == payload
+
+    def test_cli_graph_export(self, capsys):
+        payload = {"status": "ok", "format": "crg", "nodes_count": 10}
+        with (
+            patch(
+                "better_code_review_graph.tools.export_graph_dispatch",
+                return_value=payload,
+            ) as mock_exp,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "graph",
+                    "export",
+                    "--format",
+                    "crg",
+                    "--output-path",
+                    "/tmp/out.crg",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_exp.assert_called_once_with(
+            format="crg", output_path="/tmp/out.crg", repo_root=None
+        )
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_cli_graph_import(self, capsys):
+        payload = {"status": "ok", "imported_nodes": 10}
+        with (
+            patch(
+                "better_code_review_graph.tools.import_graph_dispatch",
+                return_value=payload,
+            ) as mock_imp,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "graph",
+                    "import",
+                    "--input-path",
+                    "/tmp/in.crg",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_imp.assert_called_once_with(import_path="/tmp/in.crg", repo_root=None)
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_cli_graph_summarize(self, capsys):
+        payload = {"status": "ok", "summarized": 3}
+        with (
+            patch(
+                "better_code_review_graph.tools.summarize_graph_dispatch",
+                return_value=payload,
+            ) as mock_summarize,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "graph",
+                    "summarize",
+                    "--max-nodes",
+                    "10",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_summarize.assert_called_once_with(repo_root=None, max_nodes=10)
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+
+class TestCLIQueryContract:
+    def test_cli_query_pattern(self, capsys):
+        payload = {
+            "pattern": "callers_of",
+            "target": "main",
+            "results": [{"name": "entry"}],
+        }
+        with (
+            patch(
+                "better_code_review_graph.tools.query_graph", return_value=payload
+            ) as mock_q,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "query",
+                    "query",
+                    "--pattern",
+                    "callers_of",
+                    "--target",
+                    "main",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_q.assert_called_once_with(
+            pattern="callers_of",
+            target="main",
+            repo_root=None,
+            repo="",
+            languages=None,
+            as_of="",
+        )
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_cli_query_search(self, capsys):
+        payload = {"query": "auth", "results": [{"name": "authenticate"}]}
+        with (
+            patch(
+                "better_code_review_graph.tools.semantic_search_nodes",
+                return_value=payload,
+            ) as mock_s,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "query",
+                    "search",
+                    "--search-query",
+                    "auth",
+                    "--limit",
+                    "10",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_s.assert_called_once_with(
+            query="auth",
+            repo_root=None,
+            limit=10,
+            kind=None,
+            repo="",
+            as_of="",
+        )
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_cli_query_impact(self, capsys):
+        payload = {"changed_files": ["app.py"], "impacted_files": ["main.py"]}
+        with (
+            patch(
+                "better_code_review_graph.tools.get_impact_radius", return_value=payload
+            ) as mock_imp,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "query",
+                    "impact",
+                    "--changed-files",
+                    "app.py",
+                    "auth.py",
+                    "--max-depth",
+                    "2",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_imp.assert_called_once_with(
+            changed_files=["app.py", "auth.py"],
+            base="HEAD~1",
+            repo_root=None,
+            max_depth=2,
+            max_results=500,
+            max_payload_bytes=500_000,
+            repo="",
+            as_of="",
+        )
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_cli_query_large_functions(self, capsys):
+        payload = {"results": [{"name": "huge_fn", "lines": 150}]}
+        with (
+            patch(
+                "better_code_review_graph.tools.find_large_functions",
+                return_value=payload,
+            ) as mock_lf,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "query",
+                    "large_functions",
+                    "--min-lines",
+                    "100",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_lf.assert_called_once_with(
+            min_lines=100,
+            kind="function",
+            file_path_pattern=None,
+            repo_root=None,
+            limit=50,
+            repo="",
+        )
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+
+class TestCLIReviewContract:
+    def test_cli_review_context(self, capsys):
+        payload = {"summary": "1 file changed", "impacted_nodes": []}
+        with (
+            patch(
+                "better_code_review_graph.tools.get_review_context",
+                return_value=payload,
+            ) as mock_rc,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "review",
+                    "context",
+                    "--changed-files",
+                    "src/mod.py",
+                    "--base",
+                    "main",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_rc.assert_called_once_with(
+            changed_files=["src/mod.py"],
+            base="main",
+            repo_root=None,
+            max_depth=2,
+            repo="",
+            languages=None,
+        )
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_cli_review_delta(self, capsys):
+        payload = {
+            "status": "ok",
+            "from_sha": "abc",
+            "to_sha": "def",
+            "nodes_added": [],
+        }
+        with (
+            patch(
+                "better_code_review_graph.tools.review_delta", return_value=payload
+            ) as mock_rd,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "review",
+                    "delta",
+                    "--from-sha",
+                    "abc",
+                    "--to-sha",
+                    "def",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_rd.assert_called_once_with(
+            from_sha="abc",
+            to_sha="def",
+            repo_root=None,
+            repo="",
+        )
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+
+class TestCLISecurityContract:
+    def test_cli_security_scan(self, capsys):
+        payload = {"status": "ok", "total": 0, "findings": []}
+        with (
+            patch(
+                "better_code_review_graph.tools.security_scan", return_value=payload
+            ) as mock_ss,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "security",
+                    "scan",
+                    "--engine",
+                    "heuristic",
+                    "--repo-root",
+                    "/tmp/repo",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_ss.assert_called_once_with(engine="heuristic", repo_root="/tmp/repo")
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_cli_security_report(self, capsys):
+        payload = {"status": "ok", "sarif": {"version": "2.1.0"}}
+        with (
+            patch(
+                "better_code_review_graph.tools.security_report", return_value=payload
+            ) as mock_sr,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "security",
+                    "report",
+                    "--format",
+                    "sarif",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_sr.assert_called_once_with(format="sarif", repo_root=None)
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_cli_security_suppress(self, capsys):
+        payload = {"status": "ok", "suppressions": ["CRG001"]}
+        with (
+            patch(
+                "better_code_review_graph.tools.security_suppress", return_value=payload
+            ) as mock_sup,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "security",
+                    "suppress",
+                    "--rule-id",
+                    "CRG001",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_sup.assert_called_once_with(rule_id="CRG001", remove=False, repo_root=None)
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_cli_security_rule_list(self, capsys):
+        payload = {"engine": "heuristic", "rules": []}
+        with (
+            patch(
+                "better_code_review_graph.tools.security_rule_list",
+                return_value=payload,
+            ) as mock_rl,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "security",
+                    "rule_list",
+                    "--engine",
+                    "heuristic",
+                ],
+            ),
+        ):
+            rc = main()
+
+        mock_rl.assert_called_once_with(engine="heuristic")
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_cli_error_exits_nonzero(self, capsys):
+        payload = {"error": "Repository not found"}
+        with (
+            patch(
+                "better_code_review_graph.tools.list_graph_stats", return_value=payload
+            ),
+            patch.object(sys, "argv", ["better-code-review-graph", "graph", "stats"]),
+        ):
+            rc = main()
+
+        assert rc == 1
+        assert "Repository not found" in capsys.readouterr().out

--- a/tests/test_crg_protocol_harness.py
+++ b/tests/test_crg_protocol_harness.py
@@ -104,6 +104,7 @@ async def _run_cli(*args: str) -> tuple[int, str, str]:
     return proc.returncode or 0, stdout.decode(), stderr.decode()
 
 
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_mcp_protocol_and_cli_parity(repo_fixture: Path):
     """Test full MCP stdio protocol and assert parity with CLI subcommands."""

--- a/tests/test_crg_protocol_harness.py
+++ b/tests/test_crg_protocol_harness.py
@@ -1,0 +1,345 @@
+"""Real stdio MCP protocol and CLI parity tests for CRG local harness.
+
+Exercises:
+1. Direct stdio FastMCP transport session via MCP ClientSession / stdio_client
+2. Representative domain calls: graph, query, review, security, help, config
+3. Structural output assertions, repository scoping, and error handling
+4. Parity check between CLI and MCP outputs on a real repository fixture
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+@pytest.fixture
+def repo_fixture(tmp_path: Path) -> Path:
+    """Create a git repository fixture with multiple connected Python symbols."""
+    repo_dir = tmp_path / "sample_repo"
+    repo_dir.mkdir()
+
+    # Initialize git repo
+    subprocess.run(["git", "init"], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_dir, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo_dir, check=True
+    )
+
+    # Initial file: auth.py
+    auth_py = repo_dir / "auth.py"
+    auth_py.write_text(
+        "def verify_token(token: str) -> bool:\n"
+        "    if not token:\n"
+        "        return False\n"
+        "    return True\n\n"
+        "def authenticate_user(username: str, token: str) -> dict:\n"
+        "    if verify_token(token):\n"
+        "        return {'user': username, 'authenticated': True}\n"
+        "    return {'user': username, 'authenticated': False}\n",
+        encoding="utf-8",
+    )
+
+    # Initial file: app.py
+    app_py = repo_dir / "app.py"
+    app_py.write_text(
+        "from auth import authenticate_user\n\n"
+        "def handle_login(request: dict) -> dict:\n"
+        "    user = request.get('user', '')\n"
+        "    token = request.get('token', '')\n"
+        "    return authenticate_user(user, token)\n\n"
+        "def main():\n"
+        "    res = handle_login({'user': 'alice', 'token': 'secret123'})\n"
+        "    print(res)\n",
+        encoding="utf-8",
+    )
+
+    subprocess.run(["git", "add", "."], cwd=repo_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=repo_dir, check=True)
+
+    # Second commit modifying app.py
+    app_py.write_text(
+        "from auth import authenticate_user\n\n"
+        "def handle_login(request: dict) -> dict:\n"
+        "    user = request.get('user', '')\n"
+        "    token = request.get('token', '')\n"
+        "    # Added audit log\n"
+        "    return authenticate_user(user, token)\n\n"
+        "def main():\n"
+        "    res = handle_login({'user': 'alice', 'token': 'secret123'})\n"
+        "    print(res)\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "app.py"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "Update app.py"], cwd=repo_dir, check=True)
+
+    return repo_dir
+
+
+async def _run_cli(*args: str) -> tuple[int, str, str]:
+    """Run a CLI subcommand without blocking the MCP event loop."""
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "better_code_review_graph.cli",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=8)
+    except TimeoutError as exc:
+        proc.kill()
+        await proc.wait()
+        raise AssertionError(f"CLI timed out: {args}") from exc
+    return proc.returncode or 0, stdout.decode(), stderr.decode()
+
+
+@pytest.mark.asyncio
+async def test_mcp_protocol_and_cli_parity(repo_fixture: Path):
+    """Test full MCP stdio protocol and assert parity with CLI subcommands."""
+    env = {
+        **os.environ,
+        "MCP_TRANSPORT": "stdio",
+        "PYTHONUNBUFFERED": "1",
+    }
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "better_code_review_graph"],
+        env=env,
+    )
+
+    repo_str = str(repo_fixture.resolve())
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # 1. Tools list
+            tools_result = await session.list_tools()
+            tool_names = {t.name for t in tools_result.tools}
+            expected_tools = {
+                "graph",
+                "query",
+                "review",
+                "config",
+                "help",
+                "security",
+                "config__open_relay",
+            }
+            assert expected_tools.issubset(tool_names), (
+                f"Missing tools: {expected_tools - tool_names}"
+            )
+
+            # 2. graph(action="build", full_rebuild=True)
+            res_build = await session.call_tool(
+                "graph",
+                {"action": "build", "full_rebuild": True, "repo_root": repo_str},
+            )
+            assert len(res_build.content) > 0
+            build_payload = (
+                json.loads(res_build.content[0].text)
+                if hasattr(res_build.content[0], "text")
+                else res_build.content[0]
+            )
+            assert (
+                build_payload.get("status") in ("ok", "success")
+                or "files_parsed" in build_payload
+                or "total_nodes" in build_payload
+            )
+
+            # 3. graph(action="stats")
+            res_stats = await session.call_tool(
+                "graph", {"action": "stats", "repo_root": repo_str}
+            )
+            stats_mcp = (
+                json.loads(res_stats.content[0].text)
+                if hasattr(res_stats.content[0], "text")
+                else res_stats.content[0]
+            )
+            assert stats_mcp.get("total_nodes", 0) > 0
+
+            # 4. query(action="query", pattern="callers_of", target="verify_token")
+            res_query = await session.call_tool(
+                "query",
+                {
+                    "action": "query",
+                    "pattern": "callers_of",
+                    "target": "verify_token",
+                    "repo_root": repo_str,
+                },
+            )
+            query_mcp = (
+                json.loads(res_query.content[0].text)
+                if hasattr(res_query.content[0], "text")
+                else res_query.content[0]
+            )
+            assert len(query_mcp.get("results", [])) > 0
+            caller_names_mcp = [r.get("name") for r in query_mcp["results"]]
+            assert "authenticate_user" in caller_names_mcp
+            assert all(
+                str(result["file_path"]).lower().startswith(repo_str.lower())
+                for result in query_mcp["results"]
+                if result.get("file_path")
+            )
+
+            # Explicit structured error path: oversized target is rejected.
+            res_error = await session.call_tool(
+                "query",
+                {
+                    "action": "query",
+                    "pattern": "callers_of",
+                    "target": "x" * 1001,
+                    "repo_root": repo_str,
+                },
+            )
+            error_payload = (
+                json.loads(res_error.content[0].text)
+                if hasattr(res_error.content[0], "text")
+                else res_error.content[0]
+            )
+            assert error_payload["status"] == "error"
+            assert "1000" in error_payload["error"]
+
+            # 5. query(action="search", search_query="authenticate_user")
+            res_search = await session.call_tool(
+                "query",
+                {
+                    "action": "search",
+                    "search_query": "authenticate_user",
+                    "repo_root": repo_str,
+                },
+            )
+            search_mcp = (
+                json.loads(res_search.content[0].text)
+                if hasattr(res_search.content[0], "text")
+                else res_search.content[0]
+            )
+            assert len(search_mcp.get("results", [])) > 0
+            assert any(
+                "authenticate_user" in r.get("name", "") for r in search_mcp["results"]
+            )
+
+            # 6. review(action="context", base="HEAD~1")
+            res_rev = await session.call_tool(
+                "review",
+                {
+                    "action": "context",
+                    "base": "HEAD~1",
+                    "repo_root": repo_str,
+                },
+            )
+            rev_mcp = (
+                json.loads(res_rev.content[0].text)
+                if hasattr(res_rev.content[0], "text")
+                else res_rev.content[0]
+            )
+            assert "changed_files" in rev_mcp or "summary" in rev_mcp
+
+            # 7. security(action="scan", engine="heuristic")
+            res_sec = await session.call_tool(
+                "security",
+                {
+                    "action": "scan",
+                    "engine": "heuristic",
+                    "repo_root": repo_str,
+                },
+            )
+            sec_mcp = (
+                json.loads(res_sec.content[0].text)
+                if hasattr(res_sec.content[0], "text")
+                else res_sec.content[0]
+            )
+            assert "total" in sec_mcp
+
+            # 8. config(action="status")
+            res_cfg = await session.call_tool(
+                "config", {"action": "status", "repo_root": repo_str}
+            )
+            cfg_mcp = (
+                json.loads(res_cfg.content[0].text)
+                if hasattr(res_cfg.content[0], "text")
+                else res_cfg.content[0]
+            )
+            assert "status" in cfg_mcp or "files_count" in cfg_mcp
+
+            # 9. help(topic="graph")
+            res_help = await session.call_tool("help", {"topic": "graph"})
+            help_text = (
+                res_help.content[0].text
+                if hasattr(res_help.content[0], "text")
+                else str(res_help.content[0])
+            )
+            assert "graph" in help_text.lower()
+    # Run CLI in a clean process after the stdio server has released its DB.
+    cli_rc, cli_stdout, cli_stderr = await _run_cli(
+        "graph",
+        "stats",
+        "--repo-root",
+        repo_str,
+    )
+    assert cli_rc == 0, cli_stderr
+    stats_cli = json.loads(cli_stdout)
+    assert stats_cli["total_nodes"] == stats_mcp["total_nodes"]
+    assert stats_cli["files_count"] == stats_mcp["files_count"]
+
+    cli_rc, cli_stdout, cli_stderr = await _run_cli(
+        "query",
+        "query",
+        "--pattern",
+        "callers_of",
+        "--target",
+        "verify_token",
+        "--repo-root",
+        repo_str,
+    )
+    assert cli_rc == 0, cli_stderr
+    query_cli = json.loads(cli_stdout)
+    assert "results" in query_cli, query_cli
+    caller_names_cli = [r.get("name") for r in query_cli["results"]]
+    assert caller_names_cli == caller_names_mcp
+    cli_rc, cli_stdout, cli_stderr = await _run_cli(
+        "query",
+        "impact",
+        "--repo-root",
+        repo_str,
+        "--max-depth",
+        "2",
+    )
+    assert cli_rc == 0, cli_stderr
+    impact_cli = json.loads(cli_stdout)
+    assert impact_cli["status"] == "ok"
+    assert "impacted_files" in impact_cli
+
+    cli_rc, cli_stdout, cli_stderr = await _run_cli(
+        "review",
+        "context",
+        "--base",
+        "HEAD~1",
+        "--repo-root",
+        repo_str,
+    )
+    assert cli_rc == 0, cli_stderr
+    rev_cli = json.loads(cli_stdout)
+    assert ("changed_files" in rev_cli) == ("changed_files" in rev_mcp)
+
+    cli_rc, cli_stdout, cli_stderr = await _run_cli(
+        "security",
+        "scan",
+        "--engine",
+        "heuristic",
+        "--repo-root",
+        repo_str,
+    )
+    assert cli_rc == 0, cli_stderr
+    sec_cli = json.loads(cli_stdout)
+    assert sec_cli["total"] == sec_mcp["total"]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -46,6 +46,7 @@ async def test_all_tools(tmp_path):
                 "review",
                 "config",
                 "help",
+                "security",
                 "config__open_relay",
             }
             d = json.loads(
@@ -151,6 +152,19 @@ async def test_all_tools(tmp_path):
                 )
                 > 10
             )
+            security_result = json.loads(
+                (
+                    await s.call_tool(
+                        "security",
+                        {"action": "scan", "engine": "heuristic", "repo_root": rp},
+                    )
+                )
+                .content[0]
+                .text
+            )
+            assert security_result["engine"] == "heuristic"
+            assert isinstance(security_result["total"], int)
+            assert isinstance(security_result["tags_by_node"], dict)
             assert json.loads(
                 (await s.call_tool("config", {"action": "status", "repo_root": rp}))
                 .content[0]

--- a/uv.lock
+++ b/uv.lock
@@ -199,7 +199,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.5,<2" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastmcp", specifier = ">=3.4.4,<4" },
-    { name = "fastretrieval", specifier = ">=1.0.1" },
+    { name = "fastretrieval", specifier = ">=1.1.0b1,<2" },
     { name = "httpx" },
     { name = "litellm", specifier = ">=1.93.0" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
@@ -592,7 +592,7 @@ server = [
 
 [[package]]
 name = "fastretrieval"
-version = "1.0.1"
+version = "1.1.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -603,9 +603,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/35/2a91b42d6b9784ee620d4c75bd2abadbcbd3cf304dcb0a41f5a3a22ee0ba/fastretrieval-1.0.1.tar.gz", hash = "sha256:a1d766e1c1471347ba830c4a7f280ed7b0ff86fbc48425ac457b7b9d8d0e5783", size = 330230, upload-time = "2026-08-14T16:58:25.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2b/00cccf6ead62dc473fb3eccfccd222ca9f481dc85acacb568f49700d159e/fastretrieval-1.1.0b1.tar.gz", hash = "sha256:f5d0609d8255bb66647b65071c802af7401840ba6fedd0d39f93b477fba9722e", size = 330569, upload-time = "2026-08-22T12:47:25.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/94/28ba6e0d86b4b8bb0f2a687d5669bd3c6adb7c3346d6e80431fb66ba6c2d/fastretrieval-1.0.1-py3-none-any.whl", hash = "sha256:902851b02c6b1ffefc66aa63c7976a2226696d7ea2b43b9ec471029e97e58892", size = 144199, upload-time = "2026-08-14T16:58:24.195Z" },
+    { url = "https://files.pythonhosted.org/packages/51/df/bc661390b5a1f06ec476ee23e0e9e848f865b3e80543fcb74e5bf0a254b5/fastretrieval-1.1.0b1-py3-none-any.whl", hash = "sha256:a741bb849e7324d0e11d07b23237b278e45b294c1770ef9a036a77310ebb6bad", size = 144434, upload-time = "2026-08-22T12:47:24.442Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- expose graph, query, review, and security domain services through the package CLI while retaining stdio as a secondary protocol adapter
- route all six bundled Skills through the local CLI; no MCP mapping is required
- lead installation docs with OMP/local CLI usage and move MCP configuration to the optional adapter section
- retain the W1 fastretrieval beta/model-identity contract in this combined integration branch

## OMP-owned smoke evidence
- full graph build: 2 files, 4 nodes, 6 edges
- incremental update: 1 changed file, added and modified functions identified
- callers query: `render_name` resolved as the caller of `util.py::normalize`
- review context: changed/impacted nodes and untested functions returned
- heuristic security scan: completed with structured JSON

## Verification
- CLI + protocol parity suite: 18 passed
- cold stdio protocol test has an explicit 120-second integration budget and passed
- Ruff lint/format and ty: passed
- repository pre-commit suite: passed

Stable promotion is intentionally out of scope.