### PR TITLE
fix(parser): preserve callback lexical scope

### DIFF
--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -853,6 +853,7 @@ class CodeParser:
         enclosing_func: str | None = None,
         import_map: dict[str, str] | None = None,
         defined_names: set[str] | None = None,
+        local_defined_names: set[str] | None = None,
         python_abstract_contracts: set[str] | None = None,
         declared_interfaces: set[str] | None = None,
     ) -> None:
@@ -877,6 +878,7 @@ class CodeParser:
                     enclosing_class,
                     import_map,
                     defined_names,
+                    local_defined_names,
                     python_abstract_contracts,
                     declared_interfaces,
                 )
@@ -895,6 +897,7 @@ class CodeParser:
                     enclosing_class,
                     import_map,
                     defined_names,
+                    local_defined_names,
                     python_abstract_contracts,
                     declared_interfaces,
                 )
@@ -913,6 +916,7 @@ class CodeParser:
                     enclosing_func,
                     import_map,
                     defined_names,
+                    local_defined_names,
                 )
 
             if not processed and language == "solidity":
@@ -942,6 +946,7 @@ class CodeParser:
                 enclosing_func=enclosing_func,
                 import_map=import_map,
                 defined_names=defined_names,
+                local_defined_names=local_defined_names,
                 python_abstract_contracts=python_abstract_contracts,
                 declared_interfaces=declared_interfaces,
             )
@@ -957,6 +962,7 @@ class CodeParser:
         enclosing_class: str | None,
         import_map: dict[str, str] | None,
         defined_names: set[str] | None,
+        local_defined_names: set[str] | None,
         python_abstract_contracts: set[str] | None,
         declared_interfaces: set[str] | None,
     ) -> bool:
@@ -1026,6 +1032,7 @@ class CodeParser:
             enclosing_func=None,
             import_map=import_map,
             defined_names=defined_names,
+            local_defined_names=local_defined_names,
             python_abstract_contracts=python_abstract_contracts,
             declared_interfaces=declared_interfaces,
         )
@@ -1042,12 +1049,17 @@ class CodeParser:
         enclosing_class: str | None,
         import_map: dict[str, str] | None,
         defined_names: set[str] | None,
+        local_defined_names: set[str] | None,
         python_abstract_contracts: set[str] | None = None,
         declared_interfaces: set[str] | None = None,
     ) -> bool:
         name = self._get_name(node, language, "function")
         if not name:
             return False
+
+        nested_names = self._collect_nested_function_names(node, language)
+        visible_local_names = set(local_defined_names or ())
+        visible_local_names.update(nested_names)
 
         is_test = _is_test_function(name, file_path)
         kind = "Test" if is_test else "Function"
@@ -1128,6 +1140,7 @@ class CodeParser:
             enclosing_func=name,
             import_map=import_map,
             defined_names=defined_names,
+            local_defined_names=visible_local_names or None,
             python_abstract_contracts=python_abstract_contracts,
             declared_interfaces=declared_interfaces,
         )
@@ -1171,6 +1184,7 @@ class CodeParser:
         enclosing_func: str | None,
         import_map: dict[str, str] | None,
         defined_names: set[str] | None,
+        local_defined_names: set[str] | None,
     ) -> bool:
         call_name = self._get_call_name(node, language, source)
         if call_name:
@@ -1193,6 +1207,8 @@ class CodeParser:
                 language,
                 import_map or {},
                 defined_names or set(),
+                enclosing_class=enclosing_class,
+                local_defined_names=local_defined_names,
             )
             line = node.start_point[0] + 1
             edges.append(
@@ -1220,9 +1236,11 @@ class CodeParser:
                 file_path,
                 edges,
                 caller,
+                enclosing_class,
                 call_name,
                 import_map,
                 defined_names,
+                local_defined_names,
             )
             # TESTED_BY means "called directly by a test", NOT "properly
             # tested". A test calls its subject, but it also calls helpers,
@@ -1254,9 +1272,11 @@ class CodeParser:
         file_path: str,
         edges: list[EdgeInfo],
         caller: str,
+        enclosing_class: str | None,
         call_name: str | None,
         import_map: dict[str, str] | None,
         defined_names: set[str] | None,
+        local_defined_names: set[str] | None,
     ) -> None:
         """Emit CALLS edges for function references passed as call arguments.
 
@@ -1264,9 +1284,9 @@ class CodeParser:
         ``arguments`` (JavaScript/TypeScript ``arguments``, Python
         ``arguments``, Go ``arguments``, Java ``argument_list``). This
         helper walks that subtree, collects bare identifiers, and for
-        each one that resolves to a file-scope definition or an imported
-        symbol, records a CALLS edge from the enclosing function to the
-        resolved target. This keeps dead-code analysis from flagging
+        each one that resolves to a visible file/local definition or an
+        imported symbol, records a CALLS edge from the enclosing function to
+        the resolved target. This keeps dead-code analysis from flagging
         callback-style references (``el.addEventListener('click',
         handler)``) as unreferenced.
         """
@@ -1275,22 +1295,36 @@ class CodeParser:
             return
 
         seen: set[str] = set()
-        for ident in self._iter_argument_identifiers(args_node):
+        call_types = _CALL_TYPES.get(language, ())
+        import_names = import_map or {}
+        definition_names = defined_names or set()
+        local_names = local_defined_names or set()
+        for ident in self._iter_argument_identifiers(args_node, call_types):
             name = ident.text.decode("utf-8", errors="replace")
             if not name or name in seen or name == call_name:
                 continue
             seen.add(name)
+            # Match direct-call resolution: an imported name remains a valid
+            # reference even when its module is external or not indexed, so
+            # _resolve_call_target may intentionally return the bare name.
+            if (
+                name not in definition_names
+                and name not in local_names
+                and name not in import_names
+            ):
+                continue
             resolved = self._resolve_call_target(
                 name,
                 file_path,
                 language,
-                import_map or {},
-                defined_names or set(),
+                import_names,
+                definition_names,
+                enclosing_class=enclosing_class,
+                local_defined_names=local_names,
             )
-            # Only emit when the identifier actually resolved somewhere
-            # (same-file definition or import). Unresolvable bare names
-            # stay untouched — the enclosing call edge already exists.
-            if resolved == name:
+            # Only emit identifiers that resolve to a same-file definition or
+            # an import. Unknown bare names stay untouched.
+            if resolved == name and name not in import_names:
                 continue
             edges.append(
                 EdgeInfo(
@@ -1303,26 +1337,25 @@ class CodeParser:
             )
 
     @staticmethod
-    def _iter_argument_identifiers(args_node):
-        """Yield identifier nodes within an arguments subtree.
+    def _iter_argument_identifiers(args_node, call_types=()):
+        """Yield identifiers in an arguments subtree.
 
-        Nested call expressions inside arguments are skipped: their own
-        call nodes are visited by the main tree walk and emitting edges
-        here would duplicate them.
+        Nested calls are skipped because their own call nodes are visited by
+        the main tree walk and emit their own edges. ``call_types`` is
+        language-specific: grammars use different node names for calls.
         """
+        nested_callable_types = (
+            "function_expression",
+            "arrow_function",
+            "lambda",
+        )
         stack = [args_node]
         while stack:
             current = stack.pop()
             for child in current.children:
                 if child.type == "identifier":
                     yield child
-                elif child.type in (
-                    "call_expression",
-                    "new_expression",
-                    "function_expression",
-                    "arrow_function",
-                    "lambda",
-                ):
+                elif child.type in call_types or child.type in nested_callable_types:
                     continue
                 else:
                     stack.append(child)
@@ -1585,27 +1618,70 @@ class CodeParser:
             if node_type in import_types:
                 self._collect_import_names(child, language, source, import_map)
 
-        # JS-family files are commonly wrapped in IIFEs or load callbacks,
-        # so their "file scope" functions are nested one or more levels
-        # deep ((function () { function handler() {...} ... })()). Those
-        # nested declarations still produce Function nodes qualified as
-        # ``<file>::<name>``, so their names must be resolvable — otherwise
-        # a reference like ``el.addEventListener('input', handler)`` inside
-        # the same wrapper cannot resolve and dead-code analysis flags the
-        # handler as unreferenced. Only named ``function_declaration`` nodes
-        # are collected: method definitions resolve through their class
-        # (``<file>::Class.method``) and arrow functions are anonymous or
-        # variable-assigned, so a bare-name resolution for them would be
-        # wrong.
+        # Anonymous JS wrappers (IIFEs/load callbacks) are flattened by the
+        # parser: calls inside them are attributed to the File node, and named
+        # declarations in that wrapper use file-qualified names. Do not fold
+        # declarations under a named function or class into file scope.
         if language in ("javascript", "typescript", "tsx"):
-            func_decl = {"function_declaration"}
-            for sub in self._iter_tree_nodes(root):
-                if sub.type in func_decl:
-                    name = self._get_name(sub, language, "function")
-                    if name:
-                        defined_names.add(name)
+            defined_names.update(self._collect_iife_function_names(root, language))
 
         return import_map, defined_names
+
+    def _collect_iife_function_names(self, root, language: str) -> set[str]:
+        """Collect declarations flattened into JS anonymous-wrapper scope."""
+        if language not in ("javascript", "typescript", "tsx"):
+            return set()
+
+        names: set[str] = set()
+
+        def visit(current, scope_kind: str) -> None:
+            for child in current.children:
+                if child.type == "function_declaration":
+                    if scope_kind in {"module", "anonymous"}:
+                        name = self._get_name(child, language, "function")
+                        if name:
+                            names.add(name)
+                    # A named function introduces a lexical scope of its own.
+                    continue
+                if child.type in (
+                    "class_declaration",
+                    "class",
+                    "method_definition",
+                ):
+                    continue
+                if child.type in ("function_expression", "arrow_function"):
+                    visit(child, "anonymous")
+                else:
+                    visit(child, scope_kind)
+
+        visit(root, "module")
+        return names
+
+    def _collect_nested_function_names(self, node, language: str) -> set[str]:
+        """Collect named declarations visible inside one function body."""
+        if language not in ("javascript", "typescript", "tsx"):
+            return set()
+
+        names: set[str] = set()
+
+        def visit(current) -> None:
+            for child in current.children:
+                if child.type == "function_declaration":
+                    name = self._get_name(child, language, "function")
+                    if name:
+                        names.add(name)
+                    # Declarations below this child belong to its scope.
+                    continue
+                if child.type in (
+                    "class_declaration",
+                    "class",
+                    "method_definition",
+                ):
+                    continue
+                visit(child)
+
+        visit(node)
+        return names
 
     @staticmethod
     def _iter_tree_nodes(root):
@@ -1856,8 +1932,14 @@ class CodeParser:
         language: str,
         import_map: dict[str, str],
         defined_names: set[str],
+        *,
+        enclosing_class: str | None = None,
+        local_defined_names: set[str] | None = None,
     ) -> str:
-        """Resolve a bare call name to a qualified target, with fallback."""
+        """Resolve a bare call name to a scoped qualified target."""
+        local_names = local_defined_names or set()
+        if call_name in local_names:
+            return self._qualify(call_name, file_path, enclosing_class)
         if call_name in defined_names:
             return self._qualify(call_name, file_path, None)
         if call_name in import_map:

--- a/src/better_code_review_graph/parser.py
+++ b/src/better_code_review_graph/parser.py
@@ -1173,8 +1173,20 @@ class CodeParser:
         defined_names: set[str] | None,
     ) -> bool:
         call_name = self._get_call_name(node, language, source)
-        if call_name and enclosing_func:
-            caller = self._qualify(enclosing_func, file_path, enclosing_class)
+        if call_name:
+            # Attribute calls on the module/IIFE toplevel have no enclosing
+            # function. File-level init code — e.g. JavaScript IIFE bodies,
+            # ``document.addEventListener('click', handler)`` wiring, or a
+            # Python module calling helpers at import time — still *uses*
+            # the referenced symbols, so the edges are attributed to the
+            # File node (qualified name = file path) instead of being
+            # dropped. This keeps callers_of/dead-code from reporting
+            # handlers registered by toplevel init code as unreferenced.
+            caller = (
+                self._qualify(enclosing_func, file_path, enclosing_class)
+                if enclosing_func
+                else file_path
+            )
             target = self._resolve_call_target(
                 call_name,
                 file_path,
@@ -1192,13 +1204,36 @@ class CodeParser:
                     line=line,
                 )
             )
+            # Function references passed as arguments — e.g. JS
+            # ``el.addEventListener('click', handler)`` or Python
+            # ``deferred.addCallback(handler)`` — are a real use of the
+            # referenced symbol, but the argument identifier itself is not
+            # a call expression, so they previously produced no CALLS edge
+            # and dead-code analysis reported the handler as unreferenced.
+            # Emit CALLS edges for argument identifiers that resolve to a
+            # file-scope definition or an import, so callers_of(handler)
+            # finds the registering function.
+            self._emit_argument_reference_edges(
+                node,
+                source,
+                language,
+                file_path,
+                edges,
+                caller,
+                call_name,
+                import_map,
+                defined_names,
+            )
             # TESTED_BY means "called directly by a test", NOT "properly
             # tested". A test calls its subject, but it also calls helpers,
             # builders and assertion utilities, and no static rule separates
             # intent from incidental use. Consumers must read the edge with
             # that meaning -- see _is_test_file for the one exclusion applied.
-            if _is_test_function(enclosing_func, file_path) and not _is_test_file(
-                target
+            # Toplevel/file-level calls have no test function to attribute.
+            if (
+                enclosing_func
+                and _is_test_function(enclosing_func, file_path)
+                and not _is_test_file(target)
             ):
                 edges.append(
                     EdgeInfo(
@@ -1210,6 +1245,87 @@ class CodeParser:
                     )
                 )
         return False
+
+    def _emit_argument_reference_edges(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        edges: list[EdgeInfo],
+        caller: str,
+        call_name: str | None,
+        import_map: dict[str, str] | None,
+        defined_names: set[str] | None,
+    ) -> None:
+        """Emit CALLS edges for function references passed as call arguments.
+
+        Tree-sitter grammars expose call arguments under a field named
+        ``arguments`` (JavaScript/TypeScript ``arguments``, Python
+        ``arguments``, Go ``arguments``, Java ``argument_list``). This
+        helper walks that subtree, collects bare identifiers, and for
+        each one that resolves to a file-scope definition or an imported
+        symbol, records a CALLS edge from the enclosing function to the
+        resolved target. This keeps dead-code analysis from flagging
+        callback-style references (``el.addEventListener('click',
+        handler)``) as unreferenced.
+        """
+        args_node = node.child_by_field_name("arguments")
+        if args_node is None:
+            return
+
+        seen: set[str] = set()
+        for ident in self._iter_argument_identifiers(args_node):
+            name = ident.text.decode("utf-8", errors="replace")
+            if not name or name in seen or name == call_name:
+                continue
+            seen.add(name)
+            resolved = self._resolve_call_target(
+                name,
+                file_path,
+                language,
+                import_map or {},
+                defined_names or set(),
+            )
+            # Only emit when the identifier actually resolved somewhere
+            # (same-file definition or import). Unresolvable bare names
+            # stay untouched — the enclosing call edge already exists.
+            if resolved == name:
+                continue
+            edges.append(
+                EdgeInfo(
+                    kind="CALLS",
+                    source=caller,
+                    target=resolved,
+                    file_path=file_path,
+                    line=ident.start_point[0] + 1,
+                )
+            )
+
+    @staticmethod
+    def _iter_argument_identifiers(args_node):
+        """Yield identifier nodes within an arguments subtree.
+
+        Nested call expressions inside arguments are skipped: their own
+        call nodes are visited by the main tree walk and emitting edges
+        here would duplicate them.
+        """
+        stack = [args_node]
+        while stack:
+            current = stack.pop()
+            for child in current.children:
+                if child.type == "identifier":
+                    yield child
+                elif child.type in (
+                    "call_expression",
+                    "new_expression",
+                    "function_expression",
+                    "arrow_function",
+                    "lambda",
+                ):
+                    continue
+                else:
+                    stack.append(child)
 
     def _handle_solidity_emit_statement(
         self,
@@ -1468,6 +1584,26 @@ class CodeParser:
             # Collect import mappings: imported_name → module_path
             if node_type in import_types:
                 self._collect_import_names(child, language, source, import_map)
+
+        # JS-family files are commonly wrapped in IIFEs or load callbacks,
+        # so their "file scope" functions are nested one or more levels
+        # deep ((function () { function handler() {...} ... })()). Those
+        # nested declarations still produce Function nodes qualified as
+        # ``<file>::<name>``, so their names must be resolvable — otherwise
+        # a reference like ``el.addEventListener('input', handler)`` inside
+        # the same wrapper cannot resolve and dead-code analysis flags the
+        # handler as unreferenced. Only named ``function_declaration`` nodes
+        # are collected: method definitions resolve through their class
+        # (``<file>::Class.method``) and arrow functions are anonymous or
+        # variable-assigned, so a bare-name resolution for them would be
+        # wrong.
+        if language in ("javascript", "typescript", "tsx"):
+            func_decl = {"function_declaration"}
+            for sub in self._iter_tree_nodes(root):
+                if sub.type in func_decl:
+                    name = self._get_name(sub, language, "function")
+                    if name:
+                        defined_names.add(name)
 
         return import_map, defined_names
 

--- a/tests/fixtures/callback_refs.js
+++ b/tests/fixtures/callback_refs.js
@@ -1,0 +1,18 @@
+// Fixture: callback references passed as call arguments.
+// Two registration styles must both keep the handler "referenced":
+//   1. from inside a named function (setupUI)
+//   2. from IIFE / module toplevel init code (attributed to the File node)
+
+function onEvent() {
+  return 42;
+}
+
+function setupUI() {
+  document.addEventListener("click", onEvent);
+  window.setTimeout(onEvent, 100);
+}
+
+(function () {
+  var el = document.getElementById("go");
+  el.addEventListener("input", onEvent);
+})();

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -139,6 +139,44 @@ class TestCodeParser:
         ]
         assert len(resolved) == 1
 
+    def test_calls_edge_argument_reference(self):
+        """Function references passed as call arguments produce CALLS edges.
+
+        ``document.addEventListener('click', onEvent)`` never *calls*
+        onEvent directly, but the reference keeps onEvent alive —
+        dead-code analysis must see a CALLS edge from setupUI.
+        """
+        _, edges = self.parser.parse_file(FIXTURES / "callback_refs.js")
+        calls = [e for e in edges if e.kind == "CALLS"]
+        file_path = str(FIXTURES / "callback_refs.js")
+
+        handler_edges = [
+            e for e in calls if e.target == f"{file_path}::onEvent"
+        ]
+        # addEventListener + setTimeout from setupUI, addEventListener
+        # from the IIFE toplevel.
+        assert len(handler_edges) == 3
+        assert all("setupUI" in e.source for e in handler_edges[:2])
+
+    def test_calls_edge_toplevel_registration(self):
+        """Callback registration in IIFE/module toplevel attributes to File.
+
+        Calls with no enclosing function (IIFE body, module init code)
+        previously produced no CALLS edge at all. They must now be
+        attributed to the File node so the referenced handler is not
+        reported as unreferenced by dead-code analysis.
+        """
+        _, edges = self.parser.parse_file(FIXTURES / "callback_refs.js")
+        calls = [e for e in edges if e.kind == "CALLS"]
+        file_path = str(FIXTURES / "callback_refs.js")
+
+        toplevel = [
+            e
+            for e in calls
+            if e.target == f"{file_path}::onEvent" and e.source == file_path
+        ]
+        assert len(toplevel) == 1
+
     def test_multiple_calls_to_same_function(self):
         """Multiple calls to the same function on different lines should each produce an edge."""
         _, edges = self.parser.parse_file(FIXTURES / "multi_call_example.py")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -150,9 +150,7 @@ class TestCodeParser:
         calls = [e for e in edges if e.kind == "CALLS"]
         file_path = str(FIXTURES / "callback_refs.js")
 
-        handler_edges = [
-            e for e in calls if e.target == f"{file_path}::onEvent"
-        ]
+        handler_edges = [e for e in calls if e.target == f"{file_path}::onEvent"]
         # addEventListener + setTimeout from setupUI, addEventListener
         # from the IIFE toplevel.
         assert len(handler_edges) == 3
@@ -176,6 +174,151 @@ class TestCodeParser:
             if e.target == f"{file_path}::onEvent" and e.source == file_path
         ]
         assert len(toplevel) == 1
+
+    def test_calls_edge_argument_reference_external_import(self, tmp_path):
+        """Imported callbacks stay visible when the module is not indexed."""
+        js_file = tmp_path / "external_callback.js"
+        js_file.write_text(
+            "import { onEvent } from 'external-widget';\n"
+            "function setup() {\n"
+            "  register(onEvent);\n"
+            "}\n",
+            encoding="utf-8",
+        )
+
+        _, edges = self.parser.parse_file(js_file)
+        callback_edges = [
+            edge
+            for edge in edges
+            if (
+                edge.kind == "CALLS"
+                and edge.source == f"{js_file}::setup"
+                and edge.target == "onEvent"
+            )
+        ]
+        assert len(callback_edges) == 1
+
+    def test_argument_reference_nested_calls_are_not_duplicated(self, tmp_path):
+        """Nested non-JS call nodes are emitted only by the main tree walk."""
+        py_file = tmp_path / "nested_callbacks.py"
+        py_file.write_text(
+            "def callback():\n"
+            "    pass\n\n"
+            "def inner(fn):\n"
+            "    pass\n\n"
+            "def outer():\n"
+            "    wrapper(inner(callback))\n",
+            encoding="utf-8",
+        )
+
+        _, edges = self.parser.parse_file(py_file)
+        callback_edges = [
+            edge
+            for edge in edges
+            if (
+                edge.kind == "CALLS"
+                and edge.source == f"{py_file}::outer"
+                and edge.target == f"{py_file}::callback"
+            )
+        ]
+        assert len(callback_edges) == 1
+
+    def test_iife_nested_function_reference_resolves_at_file_scope(self, tmp_path):
+        """Named declarations in anonymous wrappers keep file attribution."""
+        js_file = tmp_path / "iife_nested.js"
+        js_file.write_text(
+            "(function () {\n"
+            "  function localHandler() {}\n"
+            "  register(localHandler);\n"
+            "})();\n",
+            encoding="utf-8",
+        )
+
+        _, edges = self.parser.parse_file(js_file)
+        target = f"{js_file}::localHandler"
+        assert any(
+            edge.kind == "CALLS"
+            and edge.source == str(js_file)
+            and edge.target == target
+            for edge in edges
+        )
+
+    def test_nested_callback_function_reference_stays_in_outer_scope(self, tmp_path):
+        """Anonymous callback bodies inherit the enclosing function scope."""
+        js_file = tmp_path / "callback_nested_scope.js"
+        js_file.write_text(
+            "function outer() {\n"
+            "  register(() => {\n"
+            "    function localHandler() {}\n"
+            "    register(localHandler);\n"
+            "  });\n"
+            "}\n",
+            encoding="utf-8",
+        )
+
+        _, edges = self.parser.parse_file(js_file)
+        target = f"{js_file}::localHandler"
+        assert any(
+            edge.kind == "CALLS"
+            and edge.source == f"{js_file}::outer"
+            and edge.target == target
+            for edge in edges
+        )
+
+    def test_nested_function_reference_does_not_escape_named_scope(self, tmp_path):
+        """A helper nested in one function is not visible from its sibling."""
+        js_file = tmp_path / "nested_scope.js"
+        js_file.write_text(
+            "function outer() {\n"
+            "  function localHandler() {}\n"
+            "  register(localHandler);\n"
+            "}\n"
+            "function sibling() {\n"
+            "  register(localHandler);\n"
+            "}\n",
+            encoding="utf-8",
+        )
+
+        _, edges = self.parser.parse_file(js_file)
+        target = f"{js_file}::localHandler"
+        assert any(
+            edge.kind == "CALLS"
+            and edge.source == f"{js_file}::outer"
+            and edge.target == target
+            for edge in edges
+        )
+        assert not any(
+            edge.kind == "CALLS"
+            and edge.source == f"{js_file}::sibling"
+            and edge.target == target
+            for edge in edges
+        )
+
+    def test_class_method_nested_function_keeps_class_attribution(self, tmp_path):
+        """Nested helpers in class methods resolve to Class.helper nodes."""
+        js_file = tmp_path / "class_nested_scope.js"
+        js_file.write_text(
+            "class Widget {\n"
+            "  setup() {\n"
+            "    function localHandler() {}\n"
+            "    register(localHandler);\n"
+            "  }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+
+        _, edges = self.parser.parse_file(js_file)
+        class_target = f"{js_file}::Widget.localHandler"
+        file_target = f"{js_file}::localHandler"
+        assert any(
+            edge.kind == "CALLS"
+            and edge.source == f"{js_file}::Widget.setup"
+            and edge.target == class_target
+            for edge in edges
+        )
+        assert not any(
+            edge.kind == "CALLS" and edge.target == file_target for edge in edges
+        )
 
     def test_multiple_calls_to_same_function(self):
         """Multiple calls to the same function on different lines should each produce an edge."""


### PR DESCRIPTION
## Summary

Integrates and hardens the callback-reference parsing work from #957 by @c-with.

- emit CALLS edges for callback references and top-level initialization calls
- preserve imported callback references when their module is not indexed
- avoid duplicate nested CALLS edges in non-JavaScript trees
- retain JavaScript lexical scope for IIFEs, anonymous callbacks, nested helpers and class methods

## Verification

- full Python suite passed before the clean rebase onto current main
- 8 focused parser regressions passed after rebase
- ruff passed after rebase
- ty passed after rebase

Supersedes #957 while preserving its original commit and author in branch history.