### PR TITLE
fix: sentinel [HIGH] fix yaml comment parsing in heuristic rules

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -61,3 +61,8 @@ With the guard present git refuses to parse the value as an option at all. A `st
 - Before calling a baked-in identifier a leaked secret, check whether it is public by design.
 - Cite file and symbol names rather than line numbers, which drift as the file changes.
 - PR titles in this repo must start with `fix:` or `feat:`.
+
+## 2025-02-25 - Fix YAML parsing comment truncation
+**Vulnerability:** A simplistic YAML parser for security rules (`_parse_simple_yaml` in `heuristic.py`) blindly truncated lines at the first `#` character. This caused heuristic rules containing regexes with a literal `#` (e.g., matching URL fragments or comments) to be silently truncated, leading to false negatives in security scanning.
+**Learning:** Homegrown, "simple" parsers for structured formats like YAML often miss critical edge cases like quotes. When dealing with security configuration parsing, ignoring string boundaries allows rule logic to be unintentionally neutered.
+**Prevention:** Avoid writing custom, simplistic text parsers for standard formats. If required to avoid dependencies, ensure the parser properly accounts for string quoting when stripping comments.

--- a/src/better_code_review_graph/security/heuristic.py
+++ b/src/better_code_review_graph/security/heuristic.py
@@ -78,8 +78,26 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
 
     result: dict[str, Any] = {}
     for raw_line in text.splitlines():
-        line = raw_line.split("#", 1)[0].rstrip()
-        if not line.strip() or ":" not in line:
+        line = raw_line.strip()
+
+        # Handle comments, but only if they are not inside quotes
+        if "#" in line:
+            in_single_quote = False
+            in_double_quote = False
+            hash_idx = -1
+            for i, char in enumerate(line):
+                if char == "'" and not in_double_quote:
+                    in_single_quote = not in_single_quote
+                elif char == '"' and not in_single_quote:
+                    in_double_quote = not in_double_quote
+                elif char == "#" and not in_single_quote and not in_double_quote:
+                    hash_idx = i
+                    break
+
+            if hash_idx != -1:
+                line = line[:hash_idx].rstrip()
+
+        if not line or ":" not in line:
             continue
         key, _, value = line.partition(":")
         key = key.strip()

--- a/tests/test_security_tool.py
+++ b/tests/test_security_tool.py
@@ -408,3 +408,43 @@ def test_server_security_tool_invalid_action_returns_error() -> None:
     payload = security_tool(action="bogus")
     assert "error" in payload
     assert "bogus" in payload["error"]
+
+
+def test_parse_simple_yaml_with_hash_in_quotes():
+    from better_code_review_graph.security.heuristic import _parse_simple_yaml
+
+    yaml_text = """
+id: regex-with-hash
+severity: LOW
+pattern: 'abc#def'
+message: "Test message"
+"""
+    result = _parse_simple_yaml(yaml_text)
+    assert result["pattern"] == "abc#def"
+
+
+def test_parse_simple_yaml_with_colon_in_quotes():
+    from better_code_review_graph.security.heuristic import _parse_simple_yaml
+
+    yaml_text = """
+id: regex-with-colon
+severity: LOW
+pattern: 'http://'
+message: "Insecure http link: please update to https:// :)"
+"""
+    result = _parse_simple_yaml(yaml_text)
+    assert result["pattern"] == "http://"
+    assert result["message"] == "Insecure http link: please update to https:// :)"
+
+
+def test_parse_simple_yaml_with_comment():
+    from better_code_review_graph.security.heuristic import _parse_simple_yaml
+
+    yaml_text = """
+id: regex-with-comment
+severity: LOW
+pattern: 'abc#def' # this is a comment
+message: "Test message"
+"""
+    result = _parse_simple_yaml(yaml_text)
+    assert result["pattern"] == "abc#def"


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: 
The custom, simple YAML parser (`_parse_simple_yaml`) in `heuristic.py` incorrectly treated `#` characters inside string values as comments, blindly truncating the line at the first `#`. This caused regex patterns or messages in security rules containing `#` (e.g., matching URL fragments) to be silently truncated.

🎯 **Impact**:
Security heuristic rules could be completely neutered or rendered useless. Patterns containing literal `#` characters would fail to parse correctly, leading to false negatives during security scans because the intended pattern was truncated.

🔧 **Fix**:
Updated `_parse_simple_yaml` to parse lines character-by-character (when `#` is present), keeping track of single (`'`) and double (`"`) quote boundaries. Comments are now only stripped if the `#` occurs outside of an active quoted string. Added comprehensive unit tests to ensure literal `#` and `:` characters are parsed correctly within quotes, and actual comments outside quotes are still handled.

✅ **Verification**:
- `uv run pytest` passes (including new tests for `_parse_simple_yaml` handling quotes and comments).
- `uv run ruff check .` passes without errors.
- Appended learning to `.jules/sentinel.md` detailing the dangers of custom parsing logic for standard formats like YAML.

---
*PR created automatically by Jules for task [10310379240006835555](https://jules.google.com/task/10310379240006835555) started by @n24q02m*