### PR TITLE
fix: bolt optimization for get_stats redundant queries

### DIFF
--- a/src/better_code_review_graph/graph.py
+++ b/src/better_code_review_graph/graph.py
@@ -1339,18 +1339,6 @@ class GraphStore:
 
     def get_stats(self) -> GraphStats:
         """Return aggregate statistics about the graph."""
-        # Optimize by combining simple COUNT queries to eliminate N+1 roundtrips
-        counts = self._conn.execute(
-            "SELECT "
-            "(SELECT COUNT(*) FROM nodes), "
-            "(SELECT COUNT(*) FROM edges), "
-            "(SELECT COUNT(*) FROM nodes WHERE kind = 'File')"
-        ).fetchone()
-
-        total_nodes = counts[0]
-        total_edges = counts[1]
-        files_count = counts[2]
-
         nodes_by_kind: dict[str, int] = {}
         for row in self._conn.execute(
             "SELECT kind, COUNT(*) as cnt FROM nodes GROUP BY kind"
@@ -1362,6 +1350,11 @@ class GraphStore:
             "SELECT kind, COUNT(*) as cnt FROM edges GROUP BY kind"
         ):
             edges_by_kind[row["kind"]] = row["cnt"]
+
+        # Optimize by computing totals in Python from grouped counts to avoid redundant COUNT(*) subqueries
+        total_nodes = sum(nodes_by_kind.values())
+        total_edges = sum(edges_by_kind.values())
+        files_count = nodes_by_kind.get("File", 0)
 
         languages = [
             r["language"]


### PR DESCRIPTION
💡 What: 
Replaced redundant `COUNT(*)` subqueries with Python-side calculations in `get_stats` method within `src/better_code_review_graph/graph.py`. It uses the `nodes_by_kind` and `edges_by_kind` grouped counts.

🎯 Why: 
The function `get_stats` originally executed a query to get the total number of nodes, edges, and "File" nodes using three separate `COUNT(*)` subqueries, and then executed two more queries with a `GROUP BY kind` to get counts per kind for nodes and edges. By doing the summations natively in Python from the results of the GROUP BY queries, it avoids N+1 / redundant I/O queries and scans.

📊 Impact: 
Reduces the number of database queries executed in `get_stats` by eliminating one entirely, saving redundant scanning of table indexes for aggregate counts.

🔬 Measurement: 
No new tests were required; verified the output logic remains identical. You can trace this logic in `src/better_code_review_graph/graph.py:get_stats()`. Ensure `pytest` passes to verify there are no side effects to stats functionality.

---
*PR created automatically by Jules for task [15102062131056894642](https://jules.google.com/task/15102062131056894642) started by @n24q02m*