### PR TITLE
fix(security): fix yaml comment parsing in heuristic rules (fixes #980)

### DIFF
--- a/src/better_code_review_graph/security/heuristic.py
+++ b/src/better_code_review_graph/security/heuristic.py
@@ -78,8 +78,26 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
 
     result: dict[str, Any] = {}
     for raw_line in text.splitlines():
-        line = raw_line.split("#", 1)[0].rstrip()
-        if not line.strip() or ":" not in line:
+        line = raw_line.strip()
+
+        # Handle comments, but only if they are not inside quotes
+        if "#" in line:
+            in_single_quote = False
+            in_double_quote = False
+            hash_idx = -1
+            for i, char in enumerate(line):
+                if char == "'" and not in_double_quote:
+                    in_single_quote = not in_single_quote
+                elif char == '"' and not in_single_quote:
+                    in_double_quote = not in_double_quote
+                elif char == "#" and not in_single_quote and not in_double_quote:
+                    hash_idx = i
+                    break
+
+            if hash_idx != -1:
+                line = line[:hash_idx].rstrip()
+
+        if not line or ":" not in line:
             continue
         key, _, value = line.partition(":")
         key = key.strip()

--- a/tests/test_security_tool.py
+++ b/tests/test_security_tool.py
@@ -408,3 +408,43 @@ def test_server_security_tool_invalid_action_returns_error() -> None:
     payload = security_tool(action="bogus")
     assert "error" in payload
     assert "bogus" in payload["error"]
+
+
+def test_parse_simple_yaml_with_hash_in_quotes():
+    from better_code_review_graph.security.heuristic import _parse_simple_yaml
+
+    yaml_text = """
+id: regex-with-hash
+severity: LOW
+pattern: 'abc#def'
+message: "Test message"
+"""
+    result = _parse_simple_yaml(yaml_text)
+    assert result["pattern"] == "abc#def"
+
+
+def test_parse_simple_yaml_with_colon_in_quotes():
+    from better_code_review_graph.security.heuristic import _parse_simple_yaml
+
+    yaml_text = """
+id: regex-with-colon
+severity: LOW
+pattern: 'http://'
+message: "Insecure http link: please update to https:// :)"
+"""
+    result = _parse_simple_yaml(yaml_text)
+    assert result["pattern"] == "http://"
+    assert result["message"] == "Insecure http link: please update to https:// :)"
+
+
+def test_parse_simple_yaml_with_comment():
+    from better_code_review_graph.security.heuristic import _parse_simple_yaml
+
+    yaml_text = """
+id: regex-with-comment
+severity: LOW
+pattern: 'abc#def' # this is a comment
+message: "Test message"
+"""
+    result = _parse_simple_yaml(yaml_text)
+    assert result["pattern"] == "abc#def"


### PR DESCRIPTION
Fixes #980 by properly handling comments inside quotes in _parse_simple_yaml.