### PR TITLE
fix: repair registry publication and stable retrieval pins

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -178,6 +178,9 @@ jobs:
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
+      - name: Validate MCP Registry manifest
+        run: ./mcp-publisher validate server.json
+
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "better-code-review-graph"
 version = "3.22.0"
-description = "Knowledge graph for token-efficient code reviews -- semantic search and call-graph resolution across your codebase."
+description = "Token-efficient code review knowledge graph: semantic search and call-graph resolution."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "Apache-2.0"
 requires-python = "==3.13.*"
@@ -24,7 +24,7 @@ dependencies = [
     "tree-sitter-language-pack>=1.15.8,<2",
     "networkx>=3.6.1,<4",
     "watchdog>=6.0.0,<7",
-    "fastretrieval>=1.1.0b1,<2",
+    "fastretrieval>=1.1.0,<2",
     "httpx",
     "pydantic-settings",
     # Floor tracks the current mcp-core stable for cascade parity with
@@ -33,7 +33,7 @@ dependencies = [
     # (this repo's slug == server_name already, so no CLI regression here).
     # Keep this on a stable release -- a prerelease floor such as 1.20.0b2
     # sorts below its own stable under PEP 440 and does not require it.
-    "n24q02m-mcp-core[llm]>=1.23.0,<2",
+    "n24q02m-mcp-core[llm]>=1.23.1,<2",
     # litellm security floor (transitive via mcp-core[llm]). 1.83.x-1.87.x carry 4
     # advisories in litellm's PROXY server: GHSA-r75f-5x8p-qvmc (SQLi in proxy key
     # verify), GHSA-xqmj-j6mv-4862 (SSTI /prompts/test), GHSA-v4p8-mg3p-g94g (cmd-exec

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/better-code-review-graph",
-  "description": "Knowledge graph for token-efficient code reviews -- semantic search and call-graph resolution across your codebase.",
+  "description": "Token-efficient code review knowledge graph: semantic search and call-graph resolution.",
   "repository": {
     "url": "https://github.com/n24q02m/better-code-review-graph.git",
     "source": "github"

--- a/tests/test_oci_publication_sunset.py
+++ b/tests/test_oci_publication_sunset.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -35,6 +36,30 @@ def test_release_workflow_keeps_packages_without_public_oci_jobs():
     )
 
 
+def _named_run_steps(workflow: str, job: str) -> list[tuple[str, str | None]]:
+    """Return named release steps and their single-line ``run`` commands."""
+    block = _job_block(workflow, job)
+    steps = []
+    for match in re.finditer(
+        r"^      - name: (?P<name>[^\n]+)\n"
+        r"(?P<body>.*?)(?=^      - (?:name|uses):|\Z)",
+        block,
+        flags=re.MULTILINE | re.DOTALL,
+    ):
+        run_match = re.search(
+            r"^        run: (?P<command>[^\n]+)",
+            match.group("body"),
+            flags=re.MULTILINE,
+        )
+        steps.append(
+            (
+                match.group("name"),
+                run_match.group("command") if run_match else None,
+            )
+        )
+    return steps
+
+
 def test_registry_metadata_is_pypi_only():
     metadata = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
 
@@ -42,6 +67,55 @@ def test_registry_metadata_is_pypi_only():
     serialized = json.dumps(metadata)
     assert "docker.io/n24q02m/better-code-review-graph" not in serialized
     assert "ghcr.io/n24q02m/better-code-review-graph" not in serialized
+
+
+def test_registry_description_matches_project_metadata_and_limit():
+    metadata = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
+        "project"
+    ]
+
+    description = metadata["description"]
+    assert description == project["description"]
+    assert 0 < len(description) <= 100
+
+
+def test_embedding_dependencies_and_lock_use_stable_releases():
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
+        "project"
+    ]
+    lock = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
+    packages = {package["name"]: package for package in lock["package"]}
+
+    requirements = project["dependencies"]
+    assert "fastretrieval>=1.1.0,<2" in requirements
+    assert "n24q02m-mcp-core[llm]>=1.23.1,<2" in requirements
+    legacy_distribution = "qwen" + "3-embed"
+    assert not any(
+        legacy_distribution in requirement.casefold() for requirement in requirements
+    )
+    assert packages["fastretrieval"]["version"] == "1.1.0"
+    assert packages["n24q02m-mcp-core"]["version"] == "1.23.1"
+    assert legacy_distribution not in packages
+
+
+def test_registry_manifest_validation_precedes_authentication_and_publish():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    steps = _named_run_steps(workflow, "publish-mcp-registry")
+    names = [name for name, _ in steps]
+    commands = dict(steps)
+
+    install = names.index("Install MCP Publisher")
+    validate = names.index("Validate MCP Registry manifest")
+    login = names.index("Login to MCP Registry")
+    publish = names.index("Publish to MCP Registry")
+
+    assert install < validate < login < publish
+    assert commands["Validate MCP Registry manifest"] == (
+        "./mcp-publisher validate server.json"
+    )
+    assert commands["Login to MCP Registry"] == "./mcp-publisher login github-oidc"
+    assert commands["Publish to MCP Registry"] == "./mcp-publisher publish"
 
 
 def test_docs_keep_source_self_hosting_but_mark_public_oci_historical():

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.22.0b1"
+version = "3.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -199,11 +199,11 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.5,<2" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastmcp", specifier = ">=3.4.4,<4" },
-    { name = "fastretrieval", specifier = ">=1.1.0b1,<2" },
+    { name = "fastretrieval", specifier = ">=1.1.0,<2" },
     { name = "httpx" },
     { name = "litellm", specifier = ">=1.98.0" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.23.0,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.23.1,<2" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -620,7 +620,7 @@ server = [
 
 [[package]]
 name = "fastretrieval"
-version = "1.1.0b1"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -631,9 +631,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/2b/00cccf6ead62dc473fb3eccfccd222ca9f481dc85acacb568f49700d159e/fastretrieval-1.1.0b1.tar.gz", hash = "sha256:f5d0609d8255bb66647b65071c802af7401840ba6fedd0d39f93b477fba9722e", size = 330569, upload-time = "2026-08-22T12:47:25.801Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/be/00314cfc1aafdf3089e4384e319f32f106ca6dd63184c4583bb3e92114b2/fastretrieval-1.1.0.tar.gz", hash = "sha256:53b958b7b29a18c4ff6982bfd74c3d2b71f5e213c2ef794bbd89a0672361cdc8", size = 316103, upload-time = "2026-08-29T12:43:06.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/df/bc661390b5a1f06ec476ee23e0e9e848f865b3e80543fcb74e5bf0a254b5/fastretrieval-1.1.0b1-py3-none-any.whl", hash = "sha256:a741bb849e7324d0e11d07b23237b278e45b294c1770ef9a036a77310ebb6bad", size = 144434, upload-time = "2026-08-22T12:47:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/95/de/3e05f7c5cd33dd5716233a87e15a99c95fa8cc2c3dae53e3b0d60bc85977/fastretrieval-1.1.0-py3-none-any.whl", hash = "sha256:3c371d3fb8f76d1e029c9bd99adf8118cf0d49259c6a50649027324ba320e4ec", size = 144628, upload-time = "2026-08-29T12:43:04.505Z" },
 ]
 
 [[package]]
@@ -825,7 +825,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.28.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -838,9 +838,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/ae/222a91937ebee7f62c0ca8f5ee0afd97577caf24c0abb927d1f5c7e9f6d2/huggingface_hub-1.28.0.tar.gz", hash = "sha256:46a2e950c09234de54093d587d1675382f0d08dbd600d9fb599b5932f5b2c6cb", size = 959609, upload-time = "2026-08-18T12:27:15.101Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/35/42316e8f6908b6d21bc8df017cc6efba94fb5edbf99b64e28dd142325e20/huggingface_hub-1.29.0.tar.gz", hash = "sha256:6ebb385a581435325cf6d5c5b233d5d4bc91175834d99fd65dae14379b36e9ad", size = 963121, upload-time = "2026-08-27T12:18:37.432Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/0e/eafef18f1a75e125e68395db21131db0cf868a128ecd2fce69b4df6c584b/huggingface_hub-1.28.0-py3-none-any.whl", hash = "sha256:58a8bacb03072edfc38067065e9dc24bbb34805410fcd36a1632de0b329660bb", size = 793202, upload-time = "2026-08-18T12:27:12.719Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a5/47c2ea9b228ccbcba8467e9a64823146e8ebbad29855e591d8f5eedcc9c7/huggingface_hub-1.29.0-py3-none-any.whl", hash = "sha256:b00f7782afc14db4bc6572763810a635bdfbab8623d957bfb553bd18e03852cd", size = 795768, upload-time = "2026-08-27T12:18:35.431Z" },
 ]
 
 [[package]]
@@ -1226,7 +1226,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.23.0"
+version = "1.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1238,12 +1238,13 @@ dependencies = [
     { name = "loguru" },
     { name = "platformdirs" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/14/31d9b330fd59e891f73ad0b06e38a15f620325ef46b5cab5b6e3fd64fd83/n24q02m_mcp_core-1.23.0.tar.gz", hash = "sha256:cf6010adc23d433634d901ce550fd26f8c8fb754097a5a6e9d920ef3d48ac936", size = 358930, upload-time = "2026-08-07T22:48:12.82Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/ea/060df6d5c00c13a7e5ffe7bf04536bcbbc5577d68180d0533be3b8096f27/n24q02m_mcp_core-1.23.1.tar.gz", hash = "sha256:4408b14f73c16163048988e8b429fd73a02ffe83a4b4b8ffeef312ab843606a9", size = 364418, upload-time = "2026-08-29T12:46:36.993Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/2e/7d7a275171a6455b45df7468d0232484b68973f8e255c71696be56f70e7b/n24q02m_mcp_core-1.23.0-py3-none-any.whl", hash = "sha256:cc738b004299056419247e53da2824bd3745dc84a8cd49bf401f59e46d9e4933", size = 195465, upload-time = "2026-08-07T22:48:11.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/63/5ab34cca3f47402314622bd61e755d3c19ea4433676433a8536d6c7507df/n24q02m_mcp_core-1.23.1-py3-none-any.whl", hash = "sha256:8feac38084817544a1f9b9d256ec1b1d78584e971ab9967ba5a9526a6bbf01e6", size = 196653, upload-time = "2026-08-29T12:46:35.66Z" },
 ]
 
 [package.optional-dependencies]
@@ -1537,16 +1538,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.15.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem
Stable run 33252986656 published PyPI but MCP Registry rejected the 109-character description; marketplace sync skipped. The released source also retained beta fastretrieval/core floors.

## Fix
- align project/server descriptions to the official <=100-character limit
- run official `mcp-publisher validate server.json` before login/publish
- pin stable `fastretrieval>=1.1.0,<2` and `n24q02m-mcp-core[llm]>=1.23.1,<2`; regenerate lock
- add focused manifest/dependency/workflow regressions

The audited reset caused no substantive data loss; no stale qwen3 code is restored.

## Verification
- `uv run pytest -q tests/test_oci_publication_sunset.py` — 6 passed
- Ruff and `uv lock --check` — passed

Forward-only; no published tag is rewritten.