### PR TITLE
fix: cover semantic query acceptance metadata

### DIFF
--- a/tests/test_live_mcp.py
+++ b/tests/test_live_mcp.py
@@ -224,6 +224,53 @@ class TestLiveMCP:
                 data = _parse_result_text(result)
                 assert isinstance(data, dict), f"Unexpected response: {data}"
                 assert len(data.get("results", [])) > 0
+                assert data.get("search_mode") == "keyword"
+                header = data.get("header")
+                assert isinstance(header, dict), f"Missing response header: {data}"
+                assert header.get("embeddings_count") == 0
+                assert header.get("keyword_only") is True
+
+    async def test_query_search_after_embed(self, sample_repo: Path):
+        """A same-session embed enables semantic query mode."""
+        async with stdio_client(self._server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                await session.call_tool(
+                    "graph",
+                    {
+                        "action": "build",
+                        "full_rebuild": True,
+                        "repo_root": str(sample_repo),
+                    },
+                )
+                embed_result = await session.call_tool(
+                    "graph",
+                    {"action": "embed", "repo_root": str(sample_repo)},
+                )
+                embed_data = _parse_result_text(embed_result)
+                assert isinstance(embed_data, dict), (
+                    f"Unexpected embed response: {embed_data}"
+                )
+                assert embed_data.get("backend") == "local"
+                assert embed_data.get("newly_embedded", 0) > 0
+                assert embed_data.get("total_embeddings", 0) > 0
+
+                result = await session.call_tool(
+                    "query",
+                    {
+                        "action": "search",
+                        "search_query": "calculator",
+                        "repo_root": str(sample_repo),
+                    },
+                )
+                data = _parse_result_text(result)
+                assert isinstance(data, dict), f"Unexpected response: {data}"
+                assert data.get("search_mode") == "semantic"
+                header = data.get("header")
+                assert isinstance(header, dict), f"Missing response header: {data}"
+                assert header.get("embeddings_count", 0) > 0
+                assert header.get("keyword_only") is False
+                assert len(data.get("results", [])) > 0
 
     async def test_query_file_summary(self, sample_repo: Path):
         """query action=query with file_summary pattern."""


### PR DESCRIPTION
## Problem
Existing live query coverage built a graph but did not embed it, so it only exercised keyword fallback and did not prove the semantic MCP path.

## Change
- make the build-only query assert explicit keyword fallback metadata
- add a same-session MCP build → embed → query path
- require local embedding backend/count and semantic search/fallback header state

## Verification
- representative protocol/build/embed/query/status matrix: 6 passed
- serial full Python suite: passed
- changed-file Ruff and targeted `ty` check: passed
- local review graph: zero production nodes/dependents

## Gate status
The current MCP embed/status response does not expose selected model identity or dimensions. That remains an explicit Foundation evidence gap; this PR does not claim full Task 4 acceptance.

Note: the repository's global `ty` hook has pre-existing unrelated harness diagnostics and its Windows `bash` route resolves broken WSL; the changed file passes targeted `ty`, and the full Python suite passed serially.