### PR TITLE
feat: expose embedding selection metadata

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,8 +5,8 @@
   "userConfig": {
     "EMBEDDING_MODELS": {
       "type": "string",
-      "title": "Embedding model chain (optional)",
-      "description": "CSV 'provider/model,provider/model' (order = litellm fallback); provider inferred from prefix. Empty = local fastretrieval registry. Example: jina_ai/jina-embeddings-v5-text-small,gemini/gemini-embedding-001",
+      "title": "Embedding model selection (optional)",
+      "description": "CSV 'provider/model,provider/model'; the current runtime selects the first entry and infers its provider from the prefix. Empty = local fastretrieval registry. Example: jina_ai/jina-embeddings-v5-text-small",
       "required": false
     },
     "LOCAL_EMBEDDING_MODEL": {

--- a/README.md
+++ b/README.md
@@ -161,17 +161,17 @@ boundary: any built-in registry ID or valid non-Qwen artifact manifest follows
 the same resolver. All environment variables below are optional and only needed
 for cloud embeddings, LLM summaries, or an explicit BYO local artifact.
 
-### Model chains
+### Model selection
 
-Embeddings and summaries are each driven by an **ordered model chain** -- a
-CSV of `provider/model` entries where the order is the litellm fallback order
-(first entry is the active model). The provider is inferred from the model
-prefix, so the matching `<PROVIDER>_API_KEY` is all you need to add.
+Embeddings select the first `provider/model` entry in `EMBEDDING_MODELS`; later
+entries are retained as configuration but are not runtime fallbacks. Summaries
+use their ordered `SUMMARY_MODELS` chain. Providers are inferred from model
+prefixes and use the matching `<PROVIDER>_API_KEY`.
 
 | Variable | Purpose | Empty (default) |
 |---|---|---|
-| `EMBEDDING_MODELS` | Cloud embedding chain, e.g. `jina_ai/jina-embeddings-v5-text-small,gemini/gemini-embedding-001` | Local fastretrieval registry |
-| `SUMMARY_MODELS` | Summarizer chain for `graph(action="summarize")`, e.g. `gemini/gemini-2.5-flash,openai/gpt-4o-mini` | Summaries disabled |
+| `EMBEDDING_MODELS` | Cloud embedding selection; the first entry is active | Local fastretrieval registry |
+| `SUMMARY_MODELS` | Summarizer fallback chain for `graph(action="summarize")` | Summaries disabled |
 
 All vectors are stored at a fixed 768 dimensions (MRL truncation), so the
 embeddings table schema stays valid across providers. Switching embedding
@@ -421,7 +421,7 @@ Sources: [Greptile](https://www.greptile.com/docs/introduction) · [Greptile pri
 
 ## Security
 
-- **Graceful fallbacks** -- Cloud embedding failure falls back to local ONNX.
+- **Explicit selection** -- Cloud embedding errors are reported; the runtime does not silently switch models or fall back to local ONNX.
 - **Error handling** -- Tools return error strings with fix suggestions, never crash.
 - **Read-only mount** -- Docker mode mounts the repo as `:ro` (read-only).
 - **SSRF-guarded endpoints** -- Custom `EMBEDDING_API_BASE` / `LLM_API_BASE` URLs are validated before any outbound call.

--- a/server.json
+++ b/server.json
@@ -22,7 +22,7 @@
       },
       "environmentVariables": [
         {
-          "description": "Ordered embedding model chain 'provider/model,...'; empty = local ONNX",
+          "description": "Embedding models in selection order; the current runtime uses the first provider/model entry; empty = local ONNX",
           "isRequired": false,
           "isSecret": false,
           "name": "EMBEDDING_MODELS"

--- a/src/better_code_review_graph/docs/config.md
+++ b/src/better_code_review_graph/docs/config.md
@@ -5,7 +5,9 @@ Server configuration, status, cache management, and credential setup.
 ## Config Actions
 
 ### status
-Show current server status including graph path, node/edge counts, embedding backend, and last update time.
+Show current server status including graph counts and the selected embedding
+backend, model, fixed storage dimensions, and fallback result. Status resolves
+configuration only; it does not load the embedding model.
 
 **Parameters:**
 - `repo_root`: Repository root path (auto-detected)
@@ -22,6 +24,9 @@ Show current server status including graph path, node/edge counts, embedding bac
   "version": "2.0.0",
   "graph_path": "/path/to/.code-review-graph/graph.db",
   "embedding_backend": "local",
+  "embedding_model": "n24q02m/Qwen3-Embedding-0.6B-ONNX",
+  "embedding_dimensions": 768,
+  "embedding_fallback": "none",
   "total_nodes": 1234,
   "total_edges": 5678,
   "files_count": 42,

--- a/src/better_code_review_graph/docs/graph.md
+++ b/src/better_code_review_graph/docs/graph.md
@@ -56,12 +56,14 @@ Compute vector embeddings for all graph nodes to enable semantic search.
 **Parameters:**
 - `repo_root`: Repository root path (auto-detected)
 
-Dual-mode embedding:
-- **Local (default)**: fastretrieval built-in ONNX registry (~570MB download on first use, zero-config)
-- **Cloud**: Multi-provider (set `JINA_AI_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, or `COHERE_API_KEY` to activate)
-- **Explicit**: Set `EMBEDDING_BACKEND=local|cloud` to override
+Embedding selection:
+- **Local (default)**: the configured model or first fastretrieval built-in ONNX registry entry (~570MB download on first use, zero-config)
+- **Cloud**: the first `EMBEDDING_MODELS` entry; configured entries after it are not runtime fallbacks
+- **Unavailable**: `DISABLE_LOCAL_EMBED=true` with no cloud model configured
 
-Fixed 768-dim storage. Switching backends does NOT invalidate existing vectors.
+All vectors use fixed 768-dimension storage. Switching backends does not invalidate existing vectors.
+`config(action="status")` reports the selected backend, model, dimensions, and
+`none`/`unavailable` fallback result without loading the model.
 
 **Example:**
 ```json

--- a/src/better_code_review_graph/embeddings.py
+++ b/src/better_code_review_graph/embeddings.py
@@ -11,7 +11,7 @@ Supports two backends:
 
 Backend selection:
 - ``EMBEDDING_MODELS`` non-empty -> 'cloud' (first entry is the model).
-- Empty -> 'local' (default ONNX, always available).
+- Empty -> 'local' unless ``DISABLE_LOCAL_EMBED`` makes it unavailable.
 - Default chain keeps only models whose provider key is configured.
 - Legacy ``EMBEDDING_BACKEND`` / ``EMBEDDING_MODEL`` honored one release
   (with a deprecation warning).
@@ -172,6 +172,30 @@ class EmbeddingBackend(Protocol):  # pragma: no cover
         ...
 
 
+def _supported_local_model_ids() -> list[str]:
+    """Return public fastretrieval model IDs without loading a model."""
+    from fastretrieval import TextEmbedding
+
+    model_ids: list[str] = []
+    for item in TextEmbedding.list_supported_models():
+        model_id = (
+            item.get("model")
+            if isinstance(item, dict)
+            else getattr(item, "model", None)
+        )
+        if isinstance(model_id, str) and model_id:
+            model_ids.append(model_id)
+    return model_ids
+
+
+def _first_supported_local_model_id() -> str:
+    """Return the first public fastretrieval registry model ID."""
+    model_ids = _supported_local_model_ids()
+    if not model_ids:
+        raise ValueError("fastretrieval TextEmbedding registry is empty")
+    return model_ids[0]
+
+
 # ---------------------------------------------------------------------------
 # LocalEmbeddingBackend (local ONNX)
 # ---------------------------------------------------------------------------
@@ -204,17 +228,7 @@ class LocalEmbeddingBackend:
             from fastretrieval import TextEmbedding
 
             if self._model_name is None:
-                for item in TextEmbedding.list_supported_models():
-                    model_id = (
-                        item.get("model")
-                        if isinstance(item, dict)
-                        else getattr(item, "model", None)
-                    )
-                    if isinstance(model_id, str) and model_id:
-                        self._model_name = model_id
-                        break
-                if self._model_name is None:
-                    raise ValueError("fastretrieval TextEmbedding registry is empty")
+                self._model_name = _first_supported_local_model_id()
 
             self._model = TextEmbedding(
                 model_name=self._model_name,
@@ -335,9 +349,11 @@ def _key_available(env_var: str) -> bool:
 
 
 def resolve_embedding_chain() -> list[str]:
-    """Ordered embedding chain from EMBEDDING_MODELS (fallback order).
+    """Configured embedding models in selection order.
 
-    Empty -> local ONNX. Legacy EMBEDDING_MODEL honored one release (warning).
+    The current embedding backend selects the first entry; later entries are
+    retained as configuration but are not runtime fallbacks. Empty -> local
+    ONNX. Legacy EMBEDDING_MODEL is honored for one release (warning).
     Default keeps ONLY models whose provider key is configured; none -> empty
     -> local. Not "any key" (that would keep keyless cloud models).
 
@@ -363,6 +379,11 @@ def resolve_embedding_chain() -> list[str]:
     return [m for m in _DEFAULT_EMBEDDING_CHAIN if _key_available(key_env_for_model(m))]
 
 
+def _selected_cloud_model(model: str | None = None) -> str:
+    """Return the model CloudEmbeddingBackend will use."""
+    return model or (resolve_embedding_chain() or [_DEFAULT_EMBEDDING_CHAIN[-1]])[0]
+
+
 class CloudEmbeddingBackend:
     """Cloud embedding via ``mcp_core.llm`` (litellm passthrough).
 
@@ -378,9 +399,7 @@ class CloudEmbeddingBackend:
         model: str | None = None,
         api_key: str | None = None,
     ):
-        self.model = (
-            model or (resolve_embedding_chain() or [_DEFAULT_EMBEDDING_CHAIN[-1]])[0]
-        )
+        self.model = _selected_cloud_model(model)
         self.api_key = api_key
         self._provider = _detect_embedding_provider(self.model)
 
@@ -576,6 +595,30 @@ def resolve_backend() -> str:
         has_cloud_chain=bool(resolve_embedding_chain()),
         local_enabled=local_enabled_from_env("DISABLE_LOCAL_EMBED"),
     ).value
+
+
+def describe_backend_selection() -> dict[str, str | int | None]:
+    """Describe the selected embedding configuration without loading a model."""
+    backend = resolve_backend()
+    model: str | None = None
+
+    if backend == "cloud":
+        model = _selected_cloud_model()
+    elif backend == "local":
+        from .config import settings
+
+        configured_model = settings.local_embedding_model.strip()
+        if configured_model:
+            model, _ = _resolve_local_model_source(configured_model)
+        else:
+            model = _first_supported_local_model_id()
+
+    return {
+        "backend": backend,
+        "model": model,
+        "dimensions": _DEFAULT_DIMS,
+        "fallback": "unavailable" if backend == "unavailable" else "none",
+    }
 
 
 def init_backend(mode: str | None = None) -> EmbeddingBackend:

--- a/src/better_code_review_graph/server.py
+++ b/src/better_code_review_graph/server.py
@@ -21,7 +21,7 @@ from mcp.types import ToolAnnotations
 from mcp_core.relay.tool_helpers import register_open_relay_tool
 
 from .config import settings
-from .embeddings import EmbeddingStore, resolve_backend
+from .embeddings import EmbeddingStore, describe_backend_selection
 from .incremental import get_db_path
 from .tools import (
     build_or_update_graph,
@@ -93,18 +93,9 @@ def _register_spec(**kwargs: Any) -> None:
 
 def _built_in_model_ids() -> set[str]:
     """Đọc các model built-in từ registry, không suy luận theo tên."""
-    from fastretrieval import TextEmbedding
+    from .embeddings import _supported_local_model_ids
 
-    model_ids: set[str] = set()
-    for item in TextEmbedding.list_supported_models():
-        model_id = (
-            item.get("model")
-            if isinstance(item, dict)
-            else getattr(item, "model", None)
-        )
-        if isinstance(model_id, str):
-            model_ids.add(model_id)
-    return model_ids
+    return set(_supported_local_model_ids())
 
 
 def _maybe_register_custom_embed(local_model: str) -> None:
@@ -761,6 +752,7 @@ def _config_status(repo_root: str | None) -> dict[str, Any]:
     from .tools import _get_store
 
     version = _pkg_version
+    embedding = describe_backend_selection()
 
     try:
         store, root = _get_store(repo_root)
@@ -771,7 +763,7 @@ def _config_status(repo_root: str | None) -> dict[str, Any]:
             # Do NOT init_backend() here: constructing the local backend loads
             # the local fastretrieval ONNX model, which can block/hang the status call
             # on Windows under stdio. Open the store without a backend; the
-            # backend name is reported separately via resolve_backend().
+            # selection identity is reported separately without model construction.
             emb_store = EmbeddingStore(db_path)
             try:
                 emb_count = emb_store.count()
@@ -782,7 +774,10 @@ def _config_status(repo_root: str | None) -> dict[str, Any]:
                 "status": "ok",
                 "version": version,
                 "graph_path": str(db_path),
-                "embedding_backend": resolve_backend(),
+                "embedding_backend": embedding["backend"],
+                "embedding_model": embedding["model"],
+                "embedding_dimensions": embedding["dimensions"],
+                "embedding_fallback": embedding["fallback"],
                 "total_nodes": stats.total_nodes,
                 "total_edges": stats.total_edges,
                 "files_count": stats.files_count,
@@ -797,7 +792,10 @@ def _config_status(repo_root: str | None) -> dict[str, Any]:
             "status": "ok",
             "version": version,
             "graph_path": None,
-            "embedding_backend": resolve_backend(),
+            "embedding_backend": embedding["backend"],
+            "embedding_model": embedding["model"],
+            "embedding_dimensions": embedding["dimensions"],
+            "embedding_fallback": embedding["fallback"],
             "total_nodes": 0,
             "total_edges": 0,
             "message": "No graph found. Run graph action=build first.",

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -18,6 +18,7 @@ from better_code_review_graph.embeddings import (
     _detect_embedding_provider,
     _encode_vector,
     _strip_provider,
+    describe_backend_selection,
     embed_all_nodes,
     init_backend,
     resolve_backend,
@@ -204,6 +205,54 @@ class TestResolveBackend:
         with patch.dict(os.environ, {"DISABLE_LOCAL_EMBED": "true"}, clear=True):
             with pytest.raises(ValueError, match="DISABLE_LOCAL_EMBED"):
                 init_backend()
+
+    def test_describe_local_selection_without_loading_model(self):
+        with (
+            patch.dict(os.environ, {"EMBEDDING_BACKEND": "local"}, clear=True),
+            patch(
+                "better_code_review_graph.embeddings._first_supported_local_model_id",
+                return_value="fastretrieval/reference",
+            ),
+        ):
+            assert describe_backend_selection() == {
+                "backend": "local",
+                "model": "fastretrieval/reference",
+                "dimensions": 768,
+                "fallback": "none",
+            }
+
+    def test_describe_cloud_selection_uses_first_configured_model(self):
+        with patch.dict(
+            os.environ,
+            {
+                "EMBEDDING_BACKEND": "cloud",
+                "EMBEDDING_MODELS": "cohere/embed-v4.0,openai/text-embedding-3-large",
+            },
+            clear=True,
+        ):
+            assert describe_backend_selection() == {
+                "backend": "cloud",
+                "model": "cohere/embed-v4.0",
+                "dimensions": 768,
+                "fallback": "none",
+            }
+
+    def test_describe_legacy_cloud_matches_runtime_default_model(self):
+        with patch.dict(os.environ, {"EMBEDDING_BACKEND": "cloud"}, clear=True):
+            selection = describe_backend_selection()
+            backend = CloudEmbeddingBackend()
+
+        assert selection["model"] == backend.model
+        assert selection["model"]
+
+    def test_describe_unavailable_selection(self):
+        with patch.dict(os.environ, {"DISABLE_LOCAL_EMBED": "true"}, clear=True):
+            assert describe_backend_selection() == {
+                "backend": "unavailable",
+                "model": None,
+                "dimensions": 768,
+                "fallback": "unavailable",
+            }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_live_mcp.py
+++ b/tests/test_live_mcp.py
@@ -433,6 +433,11 @@ class TestLiveMCP:
                 assert isinstance(data, dict), f"Unexpected response: {data}"
                 assert data.get("status") == "ok"
                 assert "version" in data
+                assert data["embedding_backend"] == "local"
+                assert isinstance(data["embedding_model"], str)
+                assert data["embedding_model"]
+                assert data["embedding_dimensions"] == 768
+                assert data["embedding_fallback"] == "none"
 
     async def test_config_set_log_level(self):
         """config action=set updates log level."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -314,6 +314,10 @@ class TestConfigTool:
         assert result["status"] == "ok"
         assert "embeddings_count" in result
         assert result["embedding_backend"] in ("local", "cloud")
+        assert isinstance(result["embedding_model"], str)
+        assert result["embedding_model"]
+        assert result["embedding_dimensions"] == 768
+        assert result["embedding_fallback"] == "none"
 
     async def test_cache_clear_does_not_load_embedding_model(self, tmp_path):
         """config(cache_clear) only counts + deletes rows: no model load."""


### PR DESCRIPTION
## Change
- expose selected embedding backend, model, fixed dimensions, and fallback result from config status without loading ONNX
- reuse the public Fastretrieval registry lookup for status and runtime initialization
- keep legacy cloud selection identity aligned with the actual runtime default
- correct README, help, MCP Registry, and plugin descriptions that falsely implied embedding fallback

## Verification
- focused backend/status/custom-model tests passed
- full pytest suite reached 100% with one skip
- exact six-node live stdio build/stats/keyword/embed/semantic/status matrix: 6 passed
- Ruff, changed-source ty, uv lock, JSON checks, and scoped pre-commit: passed

Review state: REVIEW-DEGRADED-PROVIDER-QUOTA; parent and local graph review found no blocking issue.