### PR TITLE
fix: bolt optimization replacing fetchall with cursor iteration

### DIFF
--- a/src/better_code_review_graph/summarizer.py
+++ b/src/better_code_review_graph/summarizer.py
@@ -312,17 +312,20 @@ def batch_summarize(
     if not api_key and key_env == "GEMINI_API_KEY":
         api_key = config_value_for_current_request("GOOGLE_API_KEY")
 
-    rows = store._conn.execute(
+    # Performance Optimization: iterate over the cursor directly rather than
+    # materializing rows in memory using .fetchall(), which is expensive
+    # because it copies large `source_text` columns.
+    cursor = store._conn.execute(
         "SELECT id, source_text, source_hash, summary, summary_provider FROM nodes "
         "WHERE kind='Function' AND source_text IS NOT NULL LIMIT ?",
         (max_nodes,),
-    ).fetchall()
+    )
 
     generated = 0
     cached = 0
     errors = 0
 
-    for row in rows:
+    for row in cursor:
         row_id = row[0]
         src = row[1]
         stored_hash = row[2]


### PR DESCRIPTION
💡 **What:** Replaced `.fetchall()` with direct cursor iteration in `batch_summarize`.

🎯 **Why:** Using `.fetchall()` materializes the entire query result set in memory simultaneously. Since this query fetches `source_text`, which can be very large, doing so causes unnecessary peak memory spikes. Iterating over the cursor directly performs exactly the same logic but streams rows gracefully.

📊 **Impact:** Reduces peak memory overhead significantly during batch summarization tasks, preventing OOM issues on large files without any change in functionality.

🔬 **Measurement:** Verified correctness by running `uv run pytest tests/test_summarizer.py`. Performance can be assessed by profiling memory allocation before and after this change during a large batch summarization.

---
*PR created automatically by Jules for task [17889096353605177450](https://jules.google.com/task/17889096353605177450) started by @n24q02m*