### PR TITLE
fix(tests): prune ignored directories in worktree scan and extend CLI test coverage

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -161,3 +161,53 @@ class TestGraphSubcommand:
                 main()
 
         assert exc_info.value.code == 2
+
+
+class TestCliCoverageExtensions:
+    def test_version_fallback_on_package_not_found(self):
+        from importlib.metadata import PackageNotFoundError
+
+        from better_code_review_graph.cli import _version
+
+        with patch(
+            "better_code_review_graph.cli.pkg_version",
+            side_effect=PackageNotFoundError("pkg"),
+        ):
+            assert _version() == "dev"
+
+    def test_query_spot_check_and_renamed_in_diff(self, capsys):
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["better-code-review-graph", "query", "spot_check", "--n", "5"],
+            ),
+            patch(
+                "better_code_review_graph.tools.spot_check_last_callers",
+                return_value={"status": "ok"},
+            ) as mock_spot,
+        ):
+            rc = main()
+            assert rc == 0
+            mock_spot.assert_called_once()
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "better-code-review-graph",
+                    "query",
+                    "renamed_in_diff",
+                    "--base",
+                    "HEAD~1",
+                ],
+            ),
+            patch(
+                "better_code_review_graph.tools.renamed_in_diff",
+                return_value={"status": "ok"},
+            ) as mock_renamed,
+        ):
+            rc = main()
+            assert rc == 0
+            mock_renamed.assert_called_once()

--- a/tests/test_no_stale_package_name.py
+++ b/tests/test_no_stale_package_name.py
@@ -1,5 +1,6 @@
 """Không còn tham chiếu tới tên package cũ ngoài lịch sử CHANGELOG."""
 
+import os
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -18,23 +19,23 @@ IGNORED_DIRECTORIES = {
 def _worktree_hits(pattern: str) -> list[str]:
     """Scan tracked and untracked text files in the current worktree."""
     hits = []
-    for path in ROOT.rglob("*"):
-        if not path.is_file():
-            continue
-        relative = path.relative_to(ROOT)
-        if path.name in ALLOWED or any(
-            part in IGNORED_DIRECTORIES for part in relative.parts
-        ):
-            continue
-        try:
-            lines = path.read_text(encoding="utf-8").splitlines()
-        except (OSError, UnicodeDecodeError):
-            continue
-        hits.extend(
-            f"{relative}:{line_number}:{line}"
-            for line_number, line in enumerate(lines, start=1)
-            if pattern in line
-        )
+    for dirpath, dirnames, filenames in os.walk(ROOT):
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRECTORIES]
+        dir_path = Path(dirpath)
+        for filename in filenames:
+            if filename in ALLOWED:
+                continue
+            path = dir_path / filename
+            relative = path.relative_to(ROOT)
+            try:
+                lines = path.read_text(encoding="utf-8").splitlines()
+            except (OSError, UnicodeDecodeError):
+                continue
+            hits.extend(
+                f"{relative}:{line_number}:{line}"
+                for line_number, line in enumerate(lines, start=1)
+                if pattern in line
+            )
     return hits
 
 


### PR DESCRIPTION
## Summary
- Prunes ignored directories (`.venv`, `.pytest_cache`, `__pycache__`, etc.) before traversal in `_worktree_hits` with top-down `os.walk` to avoid scanning heavy dependency trees.
- Extends CLI unit test coverage for `_version` error fallback and `_handle_query` actions to keep coverage comfortably above the 95% threshold.

## Verification
- `uv run ruff check .` passed
- `uv run ruff format --check .` passed
- `uv run ty check` passed
- `uv run pytest --cov --cov-report=xml` passed with 95.12% coverage (1510 passed, 0 timeouts at default 30s timeout).