### PR TITLE
feat: add opt-in local semantic reranking

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,6 +15,12 @@
       "description": "Built-in fastretrieval model ID, or a local directory containing fastretrieval-manifest.json. External IDs require LOCAL_EMBEDDING_DIM.",
       "required": false
     },
+    "LOCAL_RERANK_MODEL": {
+      "type": "string",
+      "title": "Local reranker model (optional)",
+      "description": "Fastretrieval TextCrossEncoder model ID; empty = reranking disabled.",
+      "required": false
+    },
     "LOCAL_EMBEDDING_DIM": {
       "type": "number",
       "title": "Local embedding dimension",
@@ -92,6 +98,7 @@
         "EMBEDDING_MODELS": "${user_config.EMBEDDING_MODELS}",
         "LOCAL_EMBEDDING_MODEL": "${user_config.LOCAL_EMBEDDING_MODEL}",
         "LOCAL_EMBEDDING_DIM": "${user_config.LOCAL_EMBEDDING_DIM}",
+        "LOCAL_RERANK_MODEL": "${user_config.LOCAL_RERANK_MODEL}",
         "LOCAL_EMBEDDING_MODEL_FILE": "${user_config.LOCAL_EMBEDDING_MODEL_FILE}",
         "LOCAL_EMBEDDING_POOLING": "${user_config.LOCAL_EMBEDDING_POOLING}",
         "LOCAL_EMBEDDING_NORMALIZE": "${user_config.LOCAL_EMBEDDING_NORMALIZE}",

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ its standard `<PROVIDER>_API_KEY`.
 | `LLM_API_BASE` | Custom OpenAI-compatible base URL for the summarizer (SSRF-guarded) |
 | `DISABLE_LOCAL_EMBED` | Skip the local ONNX download; embedding is unavailable unless a cloud chain is configured |
 | `LOCAL_EMBEDDING_MODEL` | Built-in fastretrieval model ID, or a local directory containing `fastretrieval-manifest.json` | Built-in default |
+| `LOCAL_RERANK_MODEL` | Fastretrieval `TextCrossEncoder` model ID for bounded semantic reranking | Blank (disabled) |
 | `LOCAL_EMBEDDING_DIM` | Required dimension for an external model ID without a manifest | `0` |
 | `LOCAL_EMBEDDING_MODEL_FILE` | ONNX file path inside a manifest-backed artifact directory | `onnx/model.onnx` |
 | `LOCAL_EMBEDDING_POOLING` | Explicit pooling for an external ID without a manifest: `CLS`, `MEAN`, `LAST_TOKEN`, or `DISABLED` | `MEAN` |
@@ -210,10 +211,15 @@ its standard `<PROVIDER>_API_KEY`.
 | `CRG_DATA_DIR` | Override the per-user data directory (default `~/.crg`) used for per-user graphs and credentials in HTTP multi-user mode |
 | `EMBEDDING_BACKEND` / `EMBEDDING_MODEL` / `SUMMARY_MODEL` | **Deprecated** singular vars, honored one release with a warning -- migrate to the `*_MODELS` chains |
 
-CRG intentionally exposes no local reranker settings because this server has
-no local reranker path. A custom external embedding ID without a manifest must
-provide `LOCAL_EMBEDDING_DIM`; a local artifact directory must provide a valid
-`fastretrieval-manifest.json`, otherwise startup fails closed.
+When `LOCAL_RERANK_MODEL` is configured, semantic vector search retrieves a
+bounded candidate pool of `min(max(limit * 4, limit), 100)` rows, applies the
+existing `kind`, `repo`, and live-row filters, then reranks that pool and returns
+at most `limit` rows. The response uses `search_mode="semantic_reranked"` and
+adds `rerank_score` while preserving `similarity_score`. Blank keeps the
+existing `limit * 2` vector path and `search_mode="semantic"`. Configured
+reranker failures return an explicit error; CRG does not silently fall back to
+vector or keyword results. Keyword searches, including `as_of` snapshots, do
+not invoke the reranker.
 
 ### Example -- cloud embeddings + summaries
 

--- a/server.json
+++ b/server.json
@@ -34,6 +34,12 @@
           "name": "LOCAL_EMBEDDING_MODEL"
         },
         {
+          "description": "Fastretrieval TextCrossEncoder model ID; empty = reranking disabled",
+          "isRequired": false,
+          "isSecret": false,
+          "name": "LOCAL_RERANK_MODEL"
+        },
+        {
           "description": "Required positive output dimension for an external local embedding ID without a manifest",
           "isRequired": false,
           "isSecret": false,

--- a/src/better_code_review_graph/config.py
+++ b/src/better_code_review_graph/config.py
@@ -7,14 +7,15 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    """Các trường LOCAL_* cho model embedding người dùng tự cung cấp.
+    """Các trường LOCAL_* cho model embedding và reranking người dùng tự cung cấp.
 
-    CRG không có đường reranker cục bộ, vì vậy cấu hình này cố ý chỉ chứa
-    embedding. Model ngoài registry phải khai báo dimension hoặc cung cấp
+    Reranker cục bộ chỉ được bật khi ``local_rerank_model`` khác rỗng. Model
+    embedding ngoài registry phải khai báo dimension hoặc cung cấp
     ``fastretrieval-manifest.json`` trong thư mục artifact.
     """
 
     local_embedding_model: str = ""
+    local_rerank_model: str = ""
     local_embedding_dim: int = 0
     local_embedding_model_file: str = "onnx/model.onnx"
     local_embedding_pooling: str = "MEAN"
@@ -31,6 +32,7 @@ class Settings(BaseSettings):
         values = values.copy()
         for field in (
             "local_embedding_model",
+            "local_rerank_model",
             "local_embedding_dim",
             "local_embedding_model_file",
             "local_embedding_pooling",

--- a/src/better_code_review_graph/reranker.py
+++ b/src/better_code_review_graph/reranker.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+from itertools import islice
+from typing import Any
+
+
+class LocalRerankError(RuntimeError):
+    pass
+
+
+@lru_cache(maxsize=4)
+def _get_reranker(model_name: str):
+    from fastretrieval import TextCrossEncoder
+
+    return TextCrossEncoder(model_name=model_name)
+
+
+def _candidate_text(candidate: dict[str, Any]) -> str:
+    return "\n".join(
+        str(candidate.get(field) or "")
+        for field in ("kind", "qualified_name", "file_path")
+    )
+
+
+def rerank_candidates(
+    query: str,
+    candidates: list[dict[str, Any]],
+    *,
+    model_name: str,
+) -> list[dict[str, Any]]:
+    if not candidates:
+        return []
+    try:
+        scores = list(
+            islice(
+                _get_reranker(model_name).rerank(
+                    query, [_candidate_text(candidate) for candidate in candidates]
+                ),
+                len(candidates) + 1,
+            )
+        )
+    except Exception as error:
+        raise LocalRerankError(
+            f"local reranker {model_name!r} failed ({type(error).__name__})"
+        ) from error
+    if len(scores) != len(candidates):
+        raise LocalRerankError("local reranker returned the wrong score count")
+
+    ranked: list[tuple[float, int, dict[str, Any]]] = []
+    for index, (candidate, raw_score) in enumerate(
+        zip(candidates, scores, strict=True)
+    ):
+        try:
+            score = float(raw_score)
+        except (TypeError, ValueError, OverflowError) as error:
+            raise LocalRerankError(
+                "local reranker returned an invalid score"
+            ) from error
+        if not math.isfinite(score):
+            raise LocalRerankError("local reranker returned a non-finite score")
+        enriched = dict(candidate)
+        enriched["rerank_score"] = score
+        ranked.append((score, index, enriched))
+    ranked.sort(key=lambda item: (-item[0], item[1]))
+    return [item[2] for item in ranked]

--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -19,6 +19,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from .config import settings
 from .embeddings import (
     EmbeddingStore,
     embed_all_nodes,
@@ -2500,7 +2501,16 @@ def semantic_search_nodes(
             if as_of == "" and emb_store.available and emb_store.count() > 0:
                 # Vector search
                 search_mode = "semantic"
-                raw = semantic_search(query, store, emb_store, limit=limit * 2)
+                rerank_model = settings.local_rerank_model.strip()
+                if rerank_model and limit <= 0:
+                    return {
+                        "status": "error",
+                        "error": "Local reranking requires a positive limit",
+                    }
+                candidate_limit = (
+                    min(max(limit * 4, limit), 100) if rerank_model else limit * 2
+                )
+                raw = semantic_search(query, store, emb_store, limit=candidate_limit)
                 if kind:
                     raw = [r for r in raw if r.get("kind") == kind]
                 if repo:
@@ -2558,6 +2568,19 @@ def semantic_search_nodes(
                     if qn in surviving_set:
                         surviving.append(r)
                 raw = surviving
+                if rerank_model:
+                    from .reranker import LocalRerankError, rerank_candidates
+
+                    try:
+                        raw = rerank_candidates(query, raw, model_name=rerank_model)
+                    except LocalRerankError as error:
+                        return {
+                            "status": "error",
+                            "error": (
+                                f"Local reranking failed for {rerank_model!r}: {error}"
+                            ),
+                        }
+                    search_mode = "semantic_reranked"
                 raw = raw[:limit]
                 return {
                     "status": "ok",

--- a/tests/test_custom_local_model.py
+++ b/tests/test_custom_local_model.py
@@ -76,6 +76,7 @@ def test_empty_plugin_values_use_local_embedding_defaults(monkeypatch):
 
     for key in (
         "LOCAL_EMBEDDING_MODEL",
+        "LOCAL_RERANK_MODEL",
         "LOCAL_EMBEDDING_DIM",
         "LOCAL_EMBEDDING_MODEL_FILE",
         "LOCAL_EMBEDDING_POOLING",
@@ -86,6 +87,7 @@ def test_empty_plugin_values_use_local_embedding_defaults(monkeypatch):
     configured = Settings()
 
     assert configured.local_embedding_model == ""
+    assert configured.local_rerank_model == ""
     assert configured.local_embedding_dim == 0
     assert configured.local_embedding_model_file == "onnx/model.onnx"
     assert configured.local_embedding_pooling == "MEAN"

--- a/tests/test_local_reranker.py
+++ b/tests/test_local_reranker.py
@@ -1,0 +1,78 @@
+import math
+from itertools import count
+
+import pytest
+
+import better_code_review_graph.reranker as reranker
+from better_code_review_graph.reranker import LocalRerankError, rerank_candidates
+
+CANDIDATES = [
+    {
+        "kind": "Function",
+        "qualified_name": "pkg.alpha",
+        "file_path": "src/a.py",
+        "similarity_score": 0.91,
+    },
+    {
+        "kind": "Class",
+        "qualified_name": "pkg.Beta",
+        "file_path": "src/b.py",
+        "similarity_score": 0.88,
+    },
+]
+
+
+class FakeCrossEncoder:
+    def __init__(self, scores):
+        self.scores = scores
+        self.documents = None
+
+    def rerank(self, query, documents):
+        self.documents = list(documents)
+        return iter(self.scores)
+
+
+def test_rerank_uses_stable_text_and_preserves_vector_score(monkeypatch):
+    model = FakeCrossEncoder([0.2, 0.9])
+    monkeypatch.setattr(reranker, "_get_reranker", lambda _name: model)
+    result = rerank_candidates("find beta", CANDIDATES, model_name="model/id")
+    assert [row["qualified_name"] for row in result] == ["pkg.Beta", "pkg.alpha"]
+    assert result[0]["similarity_score"] == 0.88
+    assert result[0]["rerank_score"] == 0.9
+    assert model.documents == [
+        "Function\npkg.alpha\nsrc/a.py",
+        "Class\npkg.Beta\nsrc/b.py",
+    ]
+
+
+def test_rerank_preserves_original_order_for_ties(monkeypatch):
+    model = FakeCrossEncoder([0.5, 0.5])
+    monkeypatch.setattr(reranker, "_get_reranker", lambda _name: model)
+    result = rerank_candidates("q", CANDIDATES, model_name="model/id")
+    assert [row["qualified_name"] for row in result] == ["pkg.alpha", "pkg.Beta"]
+
+
+@pytest.mark.parametrize("scores", [[0.1], [0.1, math.nan], [0.1, "not-a-score"]])
+def test_rerank_rejects_incomplete_or_nonfinite_scores(monkeypatch, scores):
+    monkeypatch.setattr(
+        reranker, "_get_reranker", lambda _name: FakeCrossEncoder(scores)
+    )
+    with pytest.raises(LocalRerankError):
+        rerank_candidates("q", CANDIDATES, model_name="model/id")
+
+
+def test_rerank_bounds_overproducing_score_iterator(monkeypatch):
+    class GuardedInfiniteScores:
+        def __iter__(self):
+            for index in count():
+                if index > len(CANDIDATES):
+                    raise AssertionError("score iterator consumed beyond bound")
+                yield 0.1
+
+    monkeypatch.setattr(
+        reranker,
+        "_get_reranker",
+        lambda _name: FakeCrossEncoder(GuardedInfiniteScores()),
+    )
+    with pytest.raises(LocalRerankError, match="wrong score count"):
+        rerank_candidates("q", CANDIDATES, model_name="model/id")

--- a/tests/test_plugin_assets.py
+++ b/tests/test_plugin_assets.py
@@ -195,6 +195,21 @@ class TestHookManifest:
             assert (REPO_ROOT / rel).is_file(), rel
 
 
+def test_local_rerank_model_is_optional_and_forwarded():
+    plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
+    field = plugin["userConfig"]["LOCAL_RERANK_MODEL"]
+    assert field["type"] == "string"
+    assert field["required"] is False
+    assert (
+        plugin["mcpServers"]["better-code-review-graph"]["env"]["LOCAL_RERANK_MODEL"]
+        == "${user_config.LOCAL_RERANK_MODEL}"
+    )
+
+    server = json.loads((REPO_ROOT / "server.json").read_text())
+    names = {item["name"] for item in server["packages"][0]["environmentVariables"]}
+    assert "LOCAL_RERANK_MODEL" in names
+
+
 # ---------------------------------------------------------------------------
 # UserPromptSubmit -- stale graph warning
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_full.py
+++ b/tests/test_tools_full.py
@@ -9,9 +9,12 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+import better_code_review_graph.tools as tools
+from better_code_review_graph.config import settings
 from better_code_review_graph.embeddings import _DEFAULT_DIMS
 from better_code_review_graph.graph import GraphStore
 from better_code_review_graph.parser import EdgeInfo, NodeInfo
+from better_code_review_graph.reranker import LocalRerankError
 from better_code_review_graph.tools import (
     _BUILTIN_CALL_NAMES,
     _extract_relevant_lines,
@@ -944,6 +947,177 @@ class TestSemanticSearchWithEmbeddings:
                 query="login", kind="Function", repo_root=str(repo_with_graph)
             )
             assert result["status"] == "ok"
+
+    def test_semantic_search_blank_reranker_preserves_vector_mode(
+        self, repo_with_graph, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "local_rerank_model", "")
+        with (
+            patch(
+                "better_code_review_graph.embeddings.LocalEmbeddingBackend._get_model",
+                return_value=_stub_local_model(),
+            ),
+            patch(
+                "fastretrieval.TextCrossEncoder",
+                side_effect=AssertionError("blank config constructed a reranker"),
+            ),
+        ):
+            embed_graph(repo_root=str(repo_with_graph))
+            result = semantic_search_nodes(
+                query="authentication login",
+                limit=2,
+                repo_root=str(repo_with_graph),
+            )
+        assert result["status"] == "ok"
+        assert result["search_mode"] == "semantic"
+        assert all("rerank_score" not in row for row in result["results"])
+
+    def test_semantic_search_reranks_filtered_bounded_candidates(
+        self, repo_with_graph, monkeypatch
+    ):
+        captured = {}
+
+        def fake_rerank(query, candidates, *, model_name):
+            captured["query"] = query
+            captured["model_name"] = model_name
+            captured["candidates"] = [dict(candidate) for candidate in candidates]
+            ranked = []
+            for index, candidate in enumerate(reversed(candidates)):
+                enriched = dict(candidate)
+                enriched["rerank_score"] = 0.9 - index / 10
+                ranked.append(enriched)
+            return ranked
+
+        monkeypatch.setattr(settings, "local_rerank_model", "model/id")
+        monkeypatch.setattr(
+            "better_code_review_graph.reranker.rerank_candidates", fake_rerank
+        )
+        with patch(
+            "better_code_review_graph.embeddings.LocalEmbeddingBackend._get_model",
+            return_value=_stub_local_model(),
+        ):
+            embed_graph(repo_root=str(repo_with_graph))
+            result = semantic_search_nodes(
+                query="authentication login",
+                limit=2,
+                repo_root=str(repo_with_graph),
+            )
+
+        assert captured["query"] == "authentication login"
+        assert captured["model_name"] == "model/id"
+        assert len(captured["candidates"]) <= 8
+        assert result["status"] == "ok"
+        assert result["search_mode"] == "semantic_reranked"
+        assert len(result["results"]) <= 2
+        assert result["results"][0]["rerank_score"] == 0.9
+        assert "similarity_score" in result["results"][0]
+
+    def test_configured_semantic_search_expands_bounded_pool(
+        self, repo_with_graph, monkeypatch
+    ):
+        observed = {}
+        original_search = tools.semantic_search
+
+        def record_limit(query, store, embedding_store, limit=20):
+            observed["limit"] = limit
+            return original_search(query, store, embedding_store, limit=limit)
+
+        monkeypatch.setattr(settings, "local_rerank_model", "model/id")
+        monkeypatch.setattr(tools, "semantic_search", record_limit)
+        monkeypatch.setattr(
+            "better_code_review_graph.reranker.rerank_candidates",
+            lambda _query, candidates, *, model_name: [
+                {**candidate, "rerank_score": 0.5} for candidate in candidates
+            ],
+        )
+        with patch(
+            "better_code_review_graph.embeddings.LocalEmbeddingBackend._get_model",
+            return_value=_stub_local_model(),
+        ):
+            embed_graph(repo_root=str(repo_with_graph))
+            result = semantic_search_nodes(
+                query="authentication login",
+                limit=2,
+                repo_root=str(repo_with_graph),
+            )
+        assert result["status"] == "ok"
+        assert observed["limit"] == 8
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_configured_reranker_rejects_non_positive_limit(
+        self, repo_with_graph, monkeypatch, limit
+    ):
+        calls = []
+
+        def record_rerank(*args, **kwargs):
+            calls.append((args, kwargs))
+            return []
+
+        monkeypatch.setattr(settings, "local_rerank_model", "model/id")
+        monkeypatch.setattr(
+            "better_code_review_graph.reranker.rerank_candidates", record_rerank
+        )
+        with patch(
+            "better_code_review_graph.embeddings.LocalEmbeddingBackend._get_model",
+            return_value=_stub_local_model(),
+        ):
+            embed_graph(repo_root=str(repo_with_graph))
+            result = semantic_search_nodes(
+                query="authentication login",
+                limit=limit,
+                repo_root=str(repo_with_graph),
+            )
+
+        assert result == {
+            "status": "error",
+            "error": "Local reranking requires a positive limit",
+        }
+        assert calls == []
+
+    def test_configured_reranker_is_not_used_for_as_of(
+        self, repo_with_graph, monkeypatch
+    ):
+        def unexpected_rerank(*_args, **_kwargs):
+            raise AssertionError("historical keyword search invoked reranker")
+
+        monkeypatch.setattr(settings, "local_rerank_model", "model/id")
+        monkeypatch.setattr(
+            "better_code_review_graph.reranker.rerank_candidates", unexpected_rerank
+        )
+        result = semantic_search_nodes(
+            query="login",
+            as_of="a" * 40,
+            repo_root=str(repo_with_graph),
+        )
+        assert result["status"] == "ok"
+        assert result["search_mode"] == "keyword"
+
+    def test_configured_reranker_failure_returns_error(
+        self, repo_with_graph, monkeypatch
+    ):
+        def fail_rerank(*_args, **_kwargs):
+            raise LocalRerankError("local reranker returned the wrong score count")
+
+        monkeypatch.setattr(settings, "local_rerank_model", "model/id")
+        monkeypatch.setattr(
+            "better_code_review_graph.reranker.rerank_candidates", fail_rerank
+        )
+        with patch(
+            "better_code_review_graph.embeddings.LocalEmbeddingBackend._get_model",
+            return_value=_stub_local_model(),
+        ):
+            embed_graph(repo_root=str(repo_with_graph))
+            result = semantic_search_nodes(
+                query="authentication login",
+                repo_root=str(repo_with_graph),
+            )
+        assert result == {
+            "status": "error",
+            "error": (
+                "Local reranking failed for 'model/id': "
+                "local reranker returned the wrong score count"
+            ),
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Spec

Implements approved Phase 2 design §5 (opt-in bounded local reranking) and §7 review boundary.

## Change

- add blank-by-default `LOCAL_RERANK_MODEL` and one private lazy `TextCrossEncoder` helper
- rerank only filtered semantic candidates, bounded by `min(max(limit * 4, limit), 100)`
- preserve `similarity_score`, add finite `rerank_score`, stable ties, and `semantic_reranked` mode
- return explicit configured-path errors instead of silently falling back

`LOCAL_RERANK_MODEL` is a CRG-specific local semantic setting. It is not relay credential/mode parity; no sibling repository field is required.

## Verification

- focused reranker/tool/plugin/config suite — passed; one pre-existing Windows chmod skip
- Ruff check and format-check on changed Python files — passed
- `uv run pytest -q` — exit 0, 1524 passed and 1 skipped
- behavioral smoke — blank model stayed disabled; configured deterministic rerank reordered candidates while preserving similarity and adding rerank scores
- final cross-repository review — spec PASS; no Critical/Important finding

## Non-goals

No public Fastretrieval/mcp-core API change, extra provider/model setting, embedding-space migration, new MCP tool/action, relay/auth work, or stable promotion.

## Rollback

Leave `LOCAL_RERANK_MODEL` blank to disable immediately, or revert this PR's squash commit; no data migration is required.