### PR TITLE
fix: refresh stale local reranker docs (AGENTS/CLAUDE)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Per-task model chains, CSV `provider/model,provider/model`, order = litellm fall
 - `LOCAL_EMBEDDING_POOLING` -- explicit `CLS`, `MEAN`, `LAST_TOKEN`, or `DISABLED` value for an external ID without a manifest.
 - `LOCAL_EMBEDDING_NORMALIZE` -- explicit L2 normalization for an external ID without a manifest, default `true`.
 
-CRG không có đường reranker cục bộ nên không có cấu hình reranker local.
+CRG hỗ trợ reranker cục bộ opt-in qua `LOCAL_RERANK_MODEL` (Fastretrieval `TextCrossEncoder` model ID); bỏ trống nghĩa là tắt reranking, khi bật semantic search sẽ rerank pool kết quả và trả về `rerank_score`.
 Directory artifact thiếu manifest hoặc model ID ngoài registry thiếu dimension sẽ bị từ
 chối, không tự rơi về model mặc định.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Per-task model chains, CSV `provider/model,provider/model`, order = litellm fall
 - `LOCAL_EMBEDDING_POOLING` -- explicit `CLS`, `MEAN`, `LAST_TOKEN`, or `DISABLED` value for an external ID without a manifest.
 - `LOCAL_EMBEDDING_NORMALIZE` -- explicit L2 normalization for an external ID without a manifest, default `true`.
 
-CRG không có đường reranker cục bộ nên không có cấu hình reranker local.
+CRG hỗ trợ reranker cục bộ opt-in qua `LOCAL_RERANK_MODEL` (Fastretrieval `TextCrossEncoder` model ID); bỏ trống nghĩa là tắt reranking, khi bật semantic search sẽ rerank pool kết quả và trả về `rerank_score`.
 Directory artifact thiếu manifest hoặc model ID ngoài registry thiếu dimension sẽ bị từ
 chối, không tự rơi về model mặc định.
 


### PR DESCRIPTION
## Spec reference
MCP Phase 2 wave-2, item W2-5 (better-code-review-graph docs refresh), per approved wave-2 design.

## Change
- Rewrite the stale claim at `AGENTS.md:111` and `CLAUDE.md:111` ("CRG không có đường reranker cục bộ...") to describe the opt-in local reranker added in wave-1 PR #1004: `LOCAL_RERANK_MODEL` (Fastretrieval `TextCrossEncoder` model ID), blank = disabled, semantic search reranks the retrieved pool and returns `rerank_score`.
- Swept README.md and the repo docs tree for other stale "no local reranker" / "no reranking" claims: none found — README.md already documents `LOCAL_RERANK_MODEL` accurately (rows/lines 39, 206-222), so no further edits.
- `docs/src/content/docs/servers/` does not exist in this repo; nothing skipped there. No generated docs tree present.

## Verification
- `git grep -n -iE "no local reranker|không có.*reranker|no reranking" -- .` on the branch → no matches (exit 1), zero stale claims.
- `git diff` reviewed: 2 files, 1 line each, docs-only, no code changes.
- Pre-commit hooks on commit passed (gitleaks, trailing whitespace, merge-conflict, end-of-file, Vietnamese diacritics preserve).
- Docs-only change; no plugin-asset tests exist for these files.

## Non-goals
- No code changes, no MCP tool changes, no config renames, no release/stable surfaces.
- Did not touch any generated docs trees (none present in this repo).

## Rollback
Revert the squash commit on main.