### PR TITLE
fix: sentinel [REJECTED] document why dynamic SQL parameterized IN clauses are secure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -66,3 +66,13 @@ With the guard present git refuses to parse the value as an option at all. A `st
 **Vulnerability:** The `_get_git_content` function in `src/better_code_review_graph/tools.py` interpolated caller-supplied git refs (`base`) into pathspecs for `git show` (e.g., `f"{base}:{rel_path}"`) without explicitly rejecting inputs starting with a hyphen.
 **Learning:** Even when utilizing `--end-of-options` to delimit options from positional arguments, Git subcommand arguments constructed dynamically by interpolating refs into custom syntaxes (like tree-ish pathspecs) should proactively reject hyphens to provide defense-in-depth against complex argument injection vectors across different Git versions.
 **Prevention:** Always validate that dynamically provided git refs, SHAs, or branch names do not start with `-` before passing them to `subprocess.run`, regardless of argument separators.
+
+### 2026-09-09 - Do not replace dynamic SQL parameterized IN clauses with json_each
+
+**Rejected PR:** reported as HIGH severity SQL injection in `_kind_filter`.
+
+**Proposal:** change `_kind_filter` to return `AND kind IN (SELECT value FROM json_each(?))` instead of generating `?, ?, ?`.
+
+**Why it was rejected:** Generating `?` placeholders based on the length of a list and passing the actual values separately as a tuple is the standard, safest, and most idiomatic way to handle dynamic `IN` clauses in Python's DB-API. It is strictly parameterized and immune to SQL injection. Using `json_each` is a heavier, SQLite-specific JSON serialization workaround that provides absolutely zero additional security benefit.
+
+**Action — how to check this class of finding before reporting it:** Do not mistake parameterized placeholders (even if their number is determined dynamically based on the input list length) as a SQL injection risk. This is the correct parameterization pattern.


### PR DESCRIPTION
Adds a journal entry in `.jules/sentinel.md` documenting why generating variable numbers of placeholders (e.g., `?, ?, ?`) in `_kind_filter` is not a SQL injection vulnerability, and why replacing it with `json_each` is an unnecessary workaround that should be rejected during code review.

---
*PR created automatically by Jules for task [13055572101640551694](https://jules.google.com/task/13055572101640551694) started by @n24q02m*