### PR TITLE
fix: bolt optimization push node kind filtering to sqlite in keyword fallback search

### DIFF
--- a/src/better_code_review_graph/tools.py
+++ b/src/better_code_review_graph/tools.py
@@ -2597,10 +2597,11 @@ def semantic_search_nodes(
             emb_store.close()
 
         # Keyword fallback
-        results = store.search_nodes(query, limit=limit * 2, repo=repo, as_of=as_of)
-
-        if kind:
-            results = [r for r in results if r.kind == kind]
+        # Bolt optimization: push node kind filtering to SQLite to avoid unnecessary
+        # Python-side materialization and prevent truncating valid results.
+        results = store.search_nodes(
+            query, kind=kind, limit=limit * 2, repo=repo, as_of=as_of
+        )
 
         def score(node):
             name_lower = node.name.lower()


### PR DESCRIPTION
### What
Optimized the `semantic_search_nodes` keyword fallback logic to push the `kind` filtering down to the SQLite `search_nodes` query.

### Why
Previously, `store.search_nodes` was called without the `kind` parameter, meaning all matched nodes were materialized into Python memory, and then filtered by `kind`. If the initial result set (constrained by `limit * 2`) was saturated with nodes of the wrong kind, the subsequent Python-side filtering could result in truncating valid matches, returning far fewer results (or zero). 

### Impact
*   **Correctness:** Valid search results are no longer incorrectly truncated by applying the limit before filtering.
*   **Performance:** Avoids Python-side materialization of unnecessary database rows, preventing unnecessary Python object creation and memory overhead during search. 

### Measurement
*   The `kind` parameter is now passed directly into the query, applying the `AND kind = ?` (via the existing `_kind_filter`) logic in SQLite before returning limited rows.
*   Verified that tests (`uv run pytest`) and linters (`uv run ruff check`) still pass cleanly.

---
*PR created automatically by Jules for task [6804011392438315513](https://jules.google.com/task/6804011392438315513) started by @n24q02m*