### PR TITLE
fix: bump mcp-core to 1.24.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # (this repo's slug == server_name already, so no CLI regression here).
     # Keep this on a stable release -- a prerelease floor such as 1.20.0b2
     # sorts below its own stable under PEP 440 and does not require it.
-    "n24q02m-mcp-core[llm]==1.24.0",
+    "n24q02m-mcp-core[llm]==1.24.1",
     # litellm security floor (transitive via mcp-core[llm]). 1.83.x-1.87.x carry 4
     # advisories in litellm's PROXY server: GHSA-r75f-5x8p-qvmc (SQLi in proxy key
     # verify), GHSA-xqmj-j6mv-4862 (SSTI /prompts/test), GHSA-v4p8-mg3p-g94g (cmd-exec

--- a/tests/test_oci_publication_sunset.py
+++ b/tests/test_oci_publication_sunset.py
@@ -89,13 +89,13 @@ def test_embedding_dependencies_and_lock_use_stable_releases():
 
     requirements = project["dependencies"]
     assert "fastretrieval>=1.3.2,<2" in requirements
-    assert "n24q02m-mcp-core[llm]==1.24.0" in requirements
+    assert "n24q02m-mcp-core[llm]==1.24.1" in requirements
     legacy_distribution = "qwen" + "3-embed"
     assert not any(
         legacy_distribution in requirement.casefold() for requirement in requirements
     )
     assert packages["fastretrieval"]["version"] == "1.3.2"
-    assert packages["n24q02m-mcp-core"]["version"] == "1.24.0"
+    assert packages["n24q02m-mcp-core"]["version"] == "1.24.1"
     assert legacy_distribution not in packages
 
 

--- a/tests/test_oci_publication_sunset.py
+++ b/tests/test_oci_publication_sunset.py
@@ -88,13 +88,13 @@ def test_embedding_dependencies_and_lock_use_stable_releases():
     packages = {package["name"]: package for package in lock["package"]}
 
     requirements = project["dependencies"]
-    assert "fastretrieval>=1.3.2,<2" in requirements
+    assert "fastretrieval>=1.4.0,<2" in requirements
     assert "n24q02m-mcp-core[llm]==1.24.1" in requirements
     legacy_distribution = "qwen" + "3-embed"
     assert not any(
         legacy_distribution in requirement.casefold() for requirement in requirements
     )
-    assert packages["fastretrieval"]["version"] == "1.3.2"
+    assert packages["fastretrieval"]["version"] == "1.4.0"
     assert packages["n24q02m-mcp-core"]["version"] == "1.24.1"
     assert legacy_distribution not in packages
 

--- a/uv.lock
+++ b/uv.lock
@@ -159,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "better-code-review-graph"
-version = "3.25.2"
+version = "3.25.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -204,7 +204,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "litellm", specifier = ">=1.100.0" },
     { name = "mcp", specifier = ">=1.30.0,<2" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = "==1.24.0" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = "==1.24.1" },
     { name = "networkx", specifier = ">=3.6.1,<4" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.21.0" },
@@ -1211,7 +1211,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.24.0"
+version = "1.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1228,9 +1228,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/b9/587e76ab01578ff8b4df48624a0b634c5e4236702232cfebaf17d68c1920/n24q02m_mcp_core-1.24.0.tar.gz", hash = "sha256:fd863cefb8b33aca716f871177312d60fd9919c6c2e0f84c5ce20da0079b6751", size = 366191, upload-time = "2026-09-11T16:33:16.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/a4/62ba0f28ef9337a4d47331ae4e24338436afa5137574e925989f10153407/n24q02m_mcp_core-1.24.1.tar.gz", hash = "sha256:87af606b58ef28d4c9c8d9ba18d96b30a38e8e352735227817bb63f66ffd3f5d", size = 366278, upload-time = "2026-09-12T06:55:27.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/95/fb190ebaefdda15f1800ffa71a72d046eb72f5fdba802fdfc6b35a72e674/n24q02m_mcp_core-1.24.0-py3-none-any.whl", hash = "sha256:7a90e6ad29a4ce477aaabfb71bb117f906fdda26b2038fb5b9c7e735869e507d", size = 198405, upload-time = "2026-09-11T16:33:15.016Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b5/5a3ae939e04690e4b2aa268413d2bd75a8a7cff7c822df437e61bc32fac5/n24q02m_mcp_core-1.24.1-py3-none-any.whl", hash = "sha256:87be920bef86b933d36c0684d2e6a863857ab874e522f2dd572d349a4df27813", size = 198401, upload-time = "2026-09-12T06:55:26.627Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Auto bump lane - remediation plan `superpower/mcp-stack/plans/2026-09-12-mcp-final-remediation-plan.md` (.private @ 080e7506).

Registry evidence (readback 2026-09-12): mcp-core 1.24.1 latest on PyPI and npm, yanked=false, no prerelease.
better-code-review-graph-specific: wet-mcp also refreshes n24q02m-web-core lock to 2.7.0 (range pin >=2.5.1,<3 already allows it).

**READY-TO-MERGE**: merge is held until lane approval; a small post-approval runner does merge + release readback + tracker issue close.
